### PR TITLE
Feature: Provision Collections Directly

### DIFF
--- a/EntityDb.MongoDb.Provisioner/Commands/CreateCollectionsDirect.cs
+++ b/EntityDb.MongoDb.Provisioner/Commands/CreateCollectionsDirect.cs
@@ -1,0 +1,36 @@
+using MongoDB.Driver;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using EntityDb.MongoDb.Extensions;
+
+namespace EntityDb.MongoDb.Provisioner.Commands
+{
+    public class CreateCollectionsDirect : CommandBase
+    {
+        public static void AddTo(RootCommand rootCommand)
+        {
+            var createCollectionsDirect = new Command("create-collections-direct");
+
+            AddEntityNameArgumentTo(createCollectionsDirect);
+            
+            var connectionStringArgument = new Argument<string>("connection-string", "The connection string to the mongodb instance.");
+
+            createCollectionsDirect.AddArgument(connectionStringArgument);
+
+            createCollectionsDirect.Handler = CommandHandler.Create(async (string entityName, string connectionString) =>
+            {
+                await Execute( entityName, connectionString);
+            });
+
+            rootCommand.AddCommand(createCollectionsDirect);
+        }
+
+        public static async Task Execute(string entityName, string connectionString)
+        {
+            var mongoClient = new MongoClient(connectionString);
+
+            await mongoClient.ProvisionCollections(entityName);
+        }
+    }
+}

--- a/EntityDb.MongoDb.Provisioner/Commands/CreateCollectionsDirect.cs
+++ b/EntityDb.MongoDb.Provisioner/Commands/CreateCollectionsDirect.cs
@@ -1,8 +1,8 @@
+using EntityDb.MongoDb.Extensions;
 using MongoDB.Driver;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
-using EntityDb.MongoDb.Extensions;
 
 namespace EntityDb.MongoDb.Provisioner.Commands
 {
@@ -13,14 +13,14 @@ namespace EntityDb.MongoDb.Provisioner.Commands
             var createCollectionsDirect = new Command("create-collections-direct");
 
             AddEntityNameArgumentTo(createCollectionsDirect);
-            
+
             var connectionStringArgument = new Argument<string>("connection-string", "The connection string to the mongodb instance.");
 
             createCollectionsDirect.AddArgument(connectionStringArgument);
 
             createCollectionsDirect.Handler = CommandHandler.Create(async (string entityName, string connectionString) =>
             {
-                await Execute( entityName, connectionString);
+                await Execute(entityName, connectionString);
             });
 
             rootCommand.AddCommand(createCollectionsDirect);

--- a/EntityDb.MongoDb.Provisioner/Program.cs
+++ b/EntityDb.MongoDb.Provisioner/Program.cs
@@ -26,6 +26,7 @@ namespace EntityDb.MongoDb.Provisioner
             CreateRole.AddTo(rootCommand);
             CreateUser.AddTo(rootCommand);
             CreateCollections.AddTo(rootCommand);
+            CreateCollectionsDirect.AddTo(rootCommand);
 
             return rootCommand.InvokeAsync(args);
         }


### PR DESCRIPTION
For your provisioning needs, if MongoDb Atlas is not used, you can now use `create-collections-direct`, which takes the entity name and connection string as arguments.