### PR TITLE
chore: Delegate ToString() to encapsulated object

### DIFF
--- a/src/EntityDb.Abstractions/ValueObjects/Id.cs
+++ b/src/EntityDb.Abstractions/ValueObjects/Id.cs
@@ -13,4 +13,24 @@ public readonly record struct Id(Guid Value)
     /// </summary>
     /// <returns>A new, randomly-generated <see cref="Id"/>.</returns>
     public static Id NewId() => new(Guid.NewGuid());
+
+    /// <summary>
+    ///    Returns a string representation of the value of this instance in
+    ///    registry format.
+    /// </summary>
+    /// <returns>
+    ///     The value of this <see cref="Id" />, formatted by using the "D"
+    ///     format specifier as follows:  
+    ///
+    ///     <c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>  
+    ///
+    ///     where the value of the Id is represented as a series of lowercase
+    ///     hexadecimal digits in groups of 8, 4, 4, 4, and 12 digits and
+    ///     separated by hyphens. An example of a return value is
+    ///     "382c74c3-721d-4f34-80e5-57657b6cbc27". To convert the hexadecimal
+    ///     digits from a through f to uppercase, call the
+    ///     <see cref="M:System.String.ToUpper" /> method on the returned
+    ///     string.
+    /// </returns>
+    public override string? ToString() => Value.ToString();
 }

--- a/src/EntityDb.Abstractions/ValueObjects/TimeStamp.cs
+++ b/src/EntityDb.Abstractions/ValueObjects/TimeStamp.cs
@@ -24,4 +24,15 @@ public readonly record struct TimeStamp(DateTime Value)
     /// <returns>A <see cref="TimeStamp"/> rounded down to the nearest millisecond.</returns>
     public TimeStamp WithMillisecondPrecision() =>
         new(Value - TimeSpan.FromTicks(Value.Ticks % TimeSpan.TicksPerMillisecond));
+
+    /// <summary>
+    ///     Converts the value of the current <see cref="TimeStamp"/> object to
+    ///     its equivalent string representation using the formatting
+    ///     conventions of the current culture.
+    /// </summary>
+    /// <returns>
+    ///     A string representation of the value of the current 
+    ///     <see cref="TimeStamp"/> object.
+    /// </returns>
+    public override string? ToString() => Value.ToString();
 }

--- a/src/EntityDb.Abstractions/ValueObjects/VersionNumber.cs
+++ b/src/EntityDb.Abstractions/ValueObjects/VersionNumber.cs
@@ -16,4 +16,15 @@ public readonly record struct VersionNumber(ulong Value)
     /// </summary>
     /// <returns>The next version number.</returns>
     public VersionNumber Next() => new(Value + 1);
+
+    /// <summary>
+    ///     Converts the numeric value of this instance to its equivalent string
+    ///     representation.
+    /// </summary>
+    /// <returns>
+    ///     The string representation of the value of this instance, consisting
+    ///     of a sequence of digits ranging from 0 to 9, without a sign or
+    ///     leading zeroes.
+    /// </returns>
+    public override string? ToString() => Value.ToString();
 }


### PR DESCRIPTION
The use of `ValueObjects`, particularly when used with nullable types often leads to mistakes if relying on `toString()`. One can end up with confusing expressions like the following: `valueObject.Value.Value.toString()`.

This just overrides `toString()` to delegate it to the encapsulate it value.