### PR TITLE
Feat: Application Info in Agent Signature (via IAgentSignatureAugmenter)

### DIFF
--- a/src/EntityDb.Abstractions/Agents/IAgentSignatureAugmenter.cs
+++ b/src/EntityDb.Abstractions/Agents/IAgentSignatureAugmenter.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace EntityDb.Abstractions.Agents;
+
+/// <summary>
+///     Represents a type that can augment an agent signature by
+///     providing additional, application-specific information.
+/// </summary>
+public interface IAgentSignatureAugmenter
+{
+    /// <summary>
+    ///     Returns a dictionary of application-specific information.
+    /// </summary>
+    /// <returns>A dictionary of application-specific information.</returns>
+    Dictionary<string, string> GetApplicationInfo();
+}

--- a/src/EntityDb.Mvc/Agents/HttpContextAgent.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgent.cs
@@ -2,10 +2,16 @@
 using EntityDb.Abstractions.ValueObjects;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 
 namespace EntityDb.Mvc.Agents;
 
-internal record HttpContextAgent(HttpContext HttpContext, IOptionsFactory<HttpContextAgentSignatureOptions> HttpContextAgentSignatureOptionsFactory) : IAgent
+internal record HttpContextAgent
+(
+    HttpContext HttpContext,
+    IOptionsFactory<HttpContextAgentSignatureOptions> HttpContextAgentSignatureOptionsFactory,
+    Dictionary<string, string>? ApplicationInfo
+) : IAgent
 {
     public TimeStamp GetTimeStamp()
     {
@@ -14,6 +20,11 @@ internal record HttpContextAgent(HttpContext HttpContext, IOptionsFactory<HttpCo
 
     public object GetSignature(string signatureOptionsName)
     {
-        return HttpContextAgentSignature.GetSnapshot(HttpContext, HttpContextAgentSignatureOptionsFactory.Create(signatureOptionsName));
+        return HttpContextAgentSignature.GetSnapshot
+        (
+            HttpContext,
+            HttpContextAgentSignatureOptionsFactory.Create(signatureOptionsName),
+            ApplicationInfo
+        );
     }
 }

--- a/src/EntityDb.Mvc/Agents/HttpContextAgent.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgent.cs
@@ -10,7 +10,7 @@ internal record HttpContextAgent
 (
     HttpContext HttpContext,
     IOptionsFactory<HttpContextAgentSignatureOptions> HttpContextAgentSignatureOptionsFactory,
-    Dictionary<string, string>? ApplicationInfo
+    Dictionary<string, string> ApplicationInfo
 ) : IAgent
 {
     public TimeStamp GetTimeStamp()

--- a/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
@@ -3,6 +3,7 @@ using EntityDb.Common.Agents;
 using EntityDb.Common.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 
 namespace EntityDb.Mvc.Agents;
 
@@ -24,6 +25,8 @@ internal sealed class HttpContextAgentAccessor : AgentAccessorBase
         _agentSignatureAugmenter = agentSignatureAugmenter;
     }
 
+    private static readonly Dictionary<string, string> DefaultApplicationInfo = new();
+
     protected override IAgent CreateAgent()
     {
         var httpContext = _httpContextAccessor.HttpContext;
@@ -33,7 +36,8 @@ internal sealed class HttpContextAgentAccessor : AgentAccessorBase
             throw new NoAgentException();
         }
 
-        var applicationInfo = _agentSignatureAugmenter?.GetApplicationInfo();
+        var applicationInfo = _agentSignatureAugmenter?
+            .GetApplicationInfo() ?? DefaultApplicationInfo;
 
         return new HttpContextAgent(httpContext, _httpContextAgentOptionsFactory, applicationInfo);
     }

--- a/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
@@ -10,11 +10,18 @@ internal sealed class HttpContextAgentAccessor : AgentAccessorBase
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOptionsFactory<HttpContextAgentSignatureOptions> _httpContextAgentOptionsFactory;
+    private readonly IAgentSignatureAugmenter? _agentSignatureAugmenter;
 
-    public HttpContextAgentAccessor(IHttpContextAccessor httpContextAccessor, IOptionsFactory<HttpContextAgentSignatureOptions> httpContextAgentOptionsFactory)
+    public HttpContextAgentAccessor
+    (
+        IHttpContextAccessor httpContextAccessor,
+        IOptionsFactory<HttpContextAgentSignatureOptions> httpContextAgentOptionsFactory,
+        IAgentSignatureAugmenter? agentSignatureAugmenter = null
+    )
     {
         _httpContextAccessor = httpContextAccessor;
         _httpContextAgentOptionsFactory = httpContextAgentOptionsFactory;
+        _agentSignatureAugmenter = agentSignatureAugmenter;
     }
 
     protected override IAgent CreateAgent()
@@ -26,6 +33,8 @@ internal sealed class HttpContextAgentAccessor : AgentAccessorBase
             throw new NoAgentException();
         }
 
-        return new HttpContextAgent(httpContext, _httpContextAgentOptionsFactory);
+        var applicationInfo = _agentSignatureAugmenter?.GetApplicationInfo();
+
+        return new HttpContextAgent(httpContext, _httpContextAgentOptionsFactory, applicationInfo);
     }
 }

--- a/src/EntityDb.Mvc/Agents/HttpContextAgentSignature.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgentSignature.cs
@@ -52,7 +52,8 @@ public static class HttpContextAgentSignature
     public sealed record Snapshot
     (
         RequestSnapshot Request,
-        ConnectionSnapshot Connection
+        ConnectionSnapshot Connection,
+        Dictionary<string, string>? ApplicationInfo
     );
 
     private static NameValuesPairSnapshot[] GetNameValuesPairSnapshots(IEnumerable<KeyValuePair<string, StringValues>> dictionary, string[] redactedKeys, string redactedValue)
@@ -92,12 +93,18 @@ public static class HttpContextAgentSignature
         );
     }
 
-    internal static Snapshot GetSnapshot(HttpContext httpContext, HttpContextAgentSignatureOptions httpContextAgentOptions)
+    internal static Snapshot GetSnapshot
+    (
+        HttpContext httpContext,
+        HttpContextAgentSignatureOptions httpContextAgentOptions,
+        Dictionary<string, string>? applicationInfo
+    )
     {
         return new Snapshot
         (
             GetRequestSnapshot(httpContext.Request, httpContextAgentOptions),
-            GetConnectionSnapshot(httpContext.Connection)
+            GetConnectionSnapshot(httpContext.Connection),
+            applicationInfo
         );
     }
 }

--- a/src/EntityDb.Mvc/Agents/HttpContextAgentSignature.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgentSignature.cs
@@ -53,7 +53,7 @@ public static class HttpContextAgentSignature
     (
         RequestSnapshot Request,
         ConnectionSnapshot Connection,
-        Dictionary<string, string>? ApplicationInfo
+        Dictionary<string, string> ApplicationInfo
     );
 
     private static NameValuesPairSnapshot[] GetNameValuesPairSnapshots(IEnumerable<KeyValuePair<string, StringValues>> dictionary, string[] redactedKeys, string redactedValue)
@@ -97,7 +97,7 @@ public static class HttpContextAgentSignature
     (
         HttpContext httpContext,
         HttpContextAgentSignatureOptions httpContextAgentOptions,
-        Dictionary<string, string>? applicationInfo
+        Dictionary<string, string> applicationInfo
     )
     {
         return new Snapshot

--- a/test/EntityDb.Common.Tests/Agents/AgentAccessorTestsBase.cs
+++ b/test/EntityDb.Common.Tests/Agents/AgentAccessorTestsBase.cs
@@ -115,7 +115,7 @@ public abstract class AgentAccessorTestsBase<TStartup, TAgentAccessorConfigurati
     }
 
     [Fact]
-    public void GivenBackingServiceActiveAndNoSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnNull()
+    public void GivenBackingServiceActiveAndNoSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnEmptyApplicationInfo()
     {
         foreach (var agentAccessorConfiguration in GetAgentAccessorOptions())
         {
@@ -139,13 +139,13 @@ public abstract class AgentAccessorTestsBase<TStartup, TAgentAccessorConfigurati
 
             // ASSERT
 
-            applicationInfo.ShouldBeNull();
+            applicationInfo.ShouldBeEmpty();
         }
     }
     
 
     [Fact]
-    public void GivenBackingServiceActiveAndHasSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnApplicationInfo()
+    public void GivenBackingServiceActiveAndHasSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnExpectedApplicationInfo()
     {
         foreach (var agentAccessorConfiguration in GetAgentAccessorOptions())
         {
@@ -174,7 +174,7 @@ public abstract class AgentAccessorTestsBase<TStartup, TAgentAccessorConfigurati
 
             // ACT
 
-            var agentSignature = agentAccessor.GetAgent().GetSignature("").ShouldNotBeNull();
+            var agentSignature = agentAccessor.GetAgent().GetSignature("");
 
             var actualApplicationInfo = GetApplicationInfo(agentSignature);
 

--- a/test/EntityDb.Common.Tests/Agents/AgentAccessorTestsBase.cs
+++ b/test/EntityDb.Common.Tests/Agents/AgentAccessorTestsBase.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
 using Xunit;
 
 namespace EntityDb.Common.Tests.Agents;
@@ -18,6 +20,8 @@ public abstract class AgentAccessorTestsBase<TStartup, TAgentAccessorConfigurati
     protected abstract void ConfigureInactiveAgentAccessor(IServiceCollection serviceCollection);
 
     protected abstract void ConfigureActiveAgentAccessor(IServiceCollection serviceCollection, TAgentAccessorConfiguration agentAccessorConfiguration);
+
+    protected abstract Dictionary<string, string>? GetApplicationInfo(object agentSignature);
 
     protected abstract IEnumerable<TAgentAccessorConfiguration> GetAgentAccessorOptions();
 
@@ -107,6 +111,76 @@ public abstract class AgentAccessorTestsBase<TStartup, TAgentAccessorConfigurati
             // ASSERT
 
             agentSignature.ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public void GivenBackingServiceActiveAndNoSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnNull()
+    {
+        foreach (var agentAccessorConfiguration in GetAgentAccessorOptions())
+        {
+            // ARRANGE
+
+            using var serviceScope = CreateServiceScope(serviceCollection =>
+            {
+                ConfigureActiveAgentAccessor(serviceCollection, agentAccessorConfiguration);
+
+                serviceCollection.RemoveAll(typeof(IAgentSignatureAugmenter));
+            });
+
+            var agentAccessor = serviceScope.ServiceProvider
+                .GetRequiredService<IAgentAccessor>();
+
+            // ACT
+
+            var agentSignature = agentAccessor.GetAgent().GetSignature("").ShouldNotBeNull();
+
+            var applicationInfo = GetApplicationInfo(agentSignature);
+
+            // ASSERT
+
+            applicationInfo.ShouldBeNull();
+        }
+    }
+    
+
+    [Fact]
+    public void GivenBackingServiceActiveAndHasSignatureAugmenter_WhenGettingApplicationInfo_ThenReturnApplicationInfo()
+    {
+        foreach (var agentAccessorConfiguration in GetAgentAccessorOptions())
+        {
+            // ARRANGE
+
+            var expectedApplicationInfo = new Dictionary<string, string>
+            {
+                ["UserId"] = Guid.NewGuid().ToString()
+            };
+
+            var agentSignatureAugmenterMock = new Mock<IAgentSignatureAugmenter>(MockBehavior.Strict);
+
+            agentSignatureAugmenterMock
+                .Setup(x => x.GetApplicationInfo())
+                .Returns(expectedApplicationInfo);
+
+            using var serviceScope = CreateServiceScope(serviceCollection =>
+            {
+                ConfigureActiveAgentAccessor(serviceCollection, agentAccessorConfiguration);
+
+                serviceCollection.AddSingleton(agentSignatureAugmenterMock.Object);
+            });
+
+            var agentAccessor = serviceScope.ServiceProvider
+                .GetRequiredService<IAgentAccessor>();
+
+            // ACT
+
+            var agentSignature = agentAccessor.GetAgent().GetSignature("").ShouldNotBeNull();
+
+            var actualApplicationInfo = GetApplicationInfo(agentSignature);
+
+            // ASSERT
+
+            actualApplicationInfo.ShouldBe(expectedApplicationInfo);
         }
     }
 }

--- a/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentAccessorTests.cs
+++ b/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentAccessorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Collections.Generic;
+using EntityDb.Mvc.Agents;
 
 namespace EntityDb.Mvc.Tests.Agents;
 
@@ -57,5 +58,12 @@ public class HttpContextAgentAccessorTests : AgentAccessorTestsBase<Startup, Htt
                 HasIpAddress = false
             }
         };
+    }
+
+    protected override Dictionary<string, string>? GetApplicationInfo(object agentSignature)
+    {
+        return agentSignature is not HttpContextAgentSignature.Snapshot httpContextAgentSignature
+            ? null
+            : httpContextAgentSignature.ApplicationInfo;
     }
 }

--- a/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentSignatureTests.cs
+++ b/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentSignatureTests.cs
@@ -32,7 +32,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default!);
 
         // ASSERT
 
@@ -67,7 +67,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default!);
 
         // ASSERT
 
@@ -100,7 +100,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default!);
 
         // ASSERT
 
@@ -135,7 +135,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default!);
 
         // ASSERT
 

--- a/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentSignatureTests.cs
+++ b/test/EntityDb.Mvc.Tests/Agents/HttpContextAgentSignatureTests.cs
@@ -32,7 +32,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
 
         // ASSERT
 
@@ -67,7 +67,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
 
         // ASSERT
 
@@ -100,7 +100,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
 
         // ASSERT
 
@@ -135,7 +135,7 @@ public class HttpContextAgentSignatureTests
 
         // ACT
 
-        var (request, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions);
+        var (request, _, _) = HttpContextAgentSignature.GetSnapshot(httpContext, httpContextAgentOptions, default);
 
         // ASSERT
 

--- a/test/EntityDb.Mvc.Tests/Seeder/HttpContextSeeder.cs
+++ b/test/EntityDb.Mvc.Tests/Seeder/HttpContextSeeder.cs
@@ -15,7 +15,7 @@ public static class HttpContextSeeder
 
         connectionInfoMock
             .SetupGet(info => info.Id)
-            .Returns(Id.NewId().ToString());
+            .Returns(Id.NewId().ToString()!);
 
         var faker = new Faker();
 


### PR DESCRIPTION
Allow registering an optional service `IAgentSignatureAugmenter` which can augment any implementation of the agent signature with a dictionary of data