### PR TITLE
Refactor: Build Transactions Asynchronously

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.201",
+    "version": "6.0.300",
     "allowPrerelease": false,
     "rollForward": "disable"
   }

--- a/src/EntityDb.Abstractions/Agents/IAgentAccessor.cs
+++ b/src/EntityDb.Abstractions/Agents/IAgentAccessor.cs
@@ -1,4 +1,7 @@
-﻿namespace EntityDb.Abstractions.Agents;
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace EntityDb.Abstractions.Agents;
 
 /// <summary>
 ///     Represents a type that can access an instance of <see cref="IAgent" /> within a service scope.
@@ -8,6 +11,7 @@ public interface IAgentAccessor
     /// <summary>
     ///     Returns the agent of the service scope.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The agent of the service scope.</returns>
-    IAgent GetAgent();
+    Task<IAgent> GetAgentAsync(CancellationToken cancellationToken = default);
 }

--- a/src/EntityDb.Abstractions/Agents/IAgentSignatureAugmenter.cs
+++ b/src/EntityDb.Abstractions/Agents/IAgentSignatureAugmenter.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EntityDb.Abstractions.Agents;
 
@@ -11,6 +13,7 @@ public interface IAgentSignatureAugmenter
     /// <summary>
     ///     Returns a dictionary of application-specific information.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A dictionary of application-specific information.</returns>
-    Dictionary<string, string> GetApplicationInfo();
+    Task<Dictionary<string, string>> GetApplicationInfo(CancellationToken cancellationToken = default);
 }

--- a/src/EntityDb.Common/Agents/AgentAccessorBase.cs
+++ b/src/EntityDb.Common/Agents/AgentAccessorBase.cs
@@ -1,4 +1,6 @@
 ﻿using EntityDb.Abstractions.Agents;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EntityDb.Common.Agents;
 
@@ -6,10 +8,10 @@ internal abstract class AgentAccessorBase : IAgentAccessor
 {
     private IAgent? _agent;
 
-    protected abstract IAgent CreateAgent();
+    protected abstract Task<IAgent> CreateAgentAsync(CancellationToken cancellationToken);
 
-    public IAgent GetAgent()
+    public async Task<IAgent> GetAgentAsync(CancellationToken cancellationToken = default)
     {
-        return _agent ??= CreateAgent();
+        return _agent ??= await CreateAgentAsync(cancellationToken);
     }
 }

--- a/src/EntityDb.Common/Transactions/Builders/SingleEntityTransactionBuilder.cs
+++ b/src/EntityDb.Common/Transactions/Builders/SingleEntityTransactionBuilder.cs
@@ -3,6 +3,8 @@ using EntityDb.Abstractions.Tags;
 using EntityDb.Abstractions.Transactions;
 using EntityDb.Abstractions.ValueObjects;
 using EntityDb.Common.Entities;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EntityDb.Common.Transactions.Builders;
 
@@ -125,14 +127,15 @@ public class SingleEntityTransactionBuilder<TEntity>
     /// </summary>
     /// <param name="agentSignatureOptionsName">The name of the agent signature options.</param>
     /// <param name="transactionId">A new id for the new transaction.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A new instance of <see cref="ITransaction" />.</returns>
     /// <remarks>
     ///     Note that this is just a proxy for a <see cref="TransactionBuilder{TEntity}"/>,
     ///     and does NOT filter out steps for entity ids not associated with this
     ///     <see cref="SingleEntityTransactionBuilder{TEntity}"/>.
     /// </remarks>
-    public ITransaction Build(string agentSignatureOptionsName, Id transactionId)
+    public Task<ITransaction> BuildAsync(string agentSignatureOptionsName, Id transactionId, CancellationToken cancellationToken = default)
     {
-        return _transactionBuilder.Build(agentSignatureOptionsName, transactionId);
+        return _transactionBuilder.BuildAsync(agentSignatureOptionsName, transactionId, cancellationToken);
     }
 }

--- a/src/EntityDb.Common/Transactions/Builders/TransactionBuilder.cs
+++ b/src/EntityDb.Common/Transactions/Builders/TransactionBuilder.cs
@@ -9,12 +9,14 @@ using EntityDb.Common.Exceptions;
 using EntityDb.Common.Transactions.Steps;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EntityDb.Common.Transactions.Builders;
 
 /// <summary>
 ///     Provides a way to construct an <see cref="ITransaction" />. Note that no operations are permanent until
-///     you call <see cref="Build(string, Id)" /> and pass the result to a transaction repository.
+///     you call <see cref="BuildAsync(string, Id)" /> and pass the result to a transaction repository.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity in the transaction.</typeparam>
 public sealed class TransactionBuilder<TEntity>
@@ -231,10 +233,11 @@ public sealed class TransactionBuilder<TEntity>
     /// </summary>
     /// <param name="agentSignatureOptionsName">The name of the agent signature options.</param>
     /// <param name="transactionId">A new id for the new transaction.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A new instance of <see cref="ITransaction" />.</returns>
-    public ITransaction Build(string agentSignatureOptionsName, Id transactionId)
+    public async Task<ITransaction> BuildAsync(string agentSignatureOptionsName, Id transactionId, CancellationToken cancellationToken = default)
     {
-        var agent = _agentAccessor.GetAgent();
+        var agent = await _agentAccessor.GetAgentAsync(cancellationToken);
 
         var transaction = new Transaction
         {

--- a/test/EntityDb.Common.Tests/Entities/EntityTests.cs
+++ b/test/EntityDb.Common.Tests/Entities/EntityTests.cs
@@ -25,7 +25,7 @@ public class EntityTests : TestsBase<Startup>
     {
     }
 
-    private static ITransaction BuildTransaction
+    private static Task<ITransaction> BuildTransaction
     (
         IServiceScope serviceScope,
         Id entityId,
@@ -53,7 +53,7 @@ public class EntityTests : TestsBase<Startup>
             transactionBuilder.Append(new DoNothing());
         }
 
-        return transactionBuilder.Build(default!, Id.NewId());
+        return transactionBuilder.BuildAsync(default!, Id.NewId());
     }
 
     [Theory]
@@ -82,7 +82,7 @@ public class EntityTests : TestsBase<Startup>
             .CreateRepository(TestSessionOptions.Write,
                 TestSessionOptions.Write);
 
-        var transaction = BuildTransaction(serviceScope, entityId, new VersionNumber(1), versionNumberN);
+        var transaction = await BuildTransaction(serviceScope, entityId, new VersionNumber(1), versionNumberN);
 
         var transactionInserted = await entityRepository.PutTransaction(transaction);
 
@@ -152,7 +152,7 @@ public class EntityTests : TestsBase<Startup>
             .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
             .CreateRepository(TestSessionOptions.Write);
 
-        var transaction = BuildTransaction(serviceScope, entityId, new VersionNumber(1), expectedVersionNumber);
+        var transaction = await BuildTransaction(serviceScope, entityId, new VersionNumber(1), expectedVersionNumber);
 
         var transactionInserted = await entityRepository.PutTransaction(transaction);
 

--- a/test/EntityDb.Common.Tests/Implementations/Agents/NoAgentAccessor.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Agents/NoAgentAccessor.cs
@@ -1,11 +1,15 @@
-﻿using EntityDb.Abstractions.Agents;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EntityDb.Abstractions.Agents;
 
 namespace EntityDb.Common.Tests.Implementations.Agents;
 
 public class NoAgentAccessor : IAgentAccessor
 {
-    public IAgent GetAgent()
+    public async Task<IAgent> GetAgentAsync(CancellationToken cancellationToken = default)
     {
+        await Task.Yield();
+
         return new NoAgent();
     }
 }

--- a/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
@@ -73,7 +73,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
     }
 
     [Fact]
-    public void GivenLeasingStrategy_WhenBuildingNewEntityWithLease_ThenTransactionDoesInsertLeases()
+    public async Task GivenLeasingStrategy_WhenBuildingNewEntityWithLease_ThenTransactionDoesInsertLeases()
     {
         // ARRANGE
 
@@ -85,9 +85,9 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         // ACT
 
-        var transaction = transactionBuilder
+        var transaction = await transactionBuilder
             .Add(new Lease(default!, default!, default!))
-            .Build(default!, default);
+            .BuildAsync(default!, default);
 
         // ASSERT
 
@@ -135,7 +135,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
     }
 
     [Fact]
-    public void GivenNonExistingEntityId_WhenUsingValidVersioningStrategy_ThenVersionNumberAutoIncrements()
+    public async Task GivenNonExistingEntityId_WhenUsingValidVersioningStrategy_ThenVersionNumberAutoIncrements()
     {
         // ARRANGE
 
@@ -160,7 +160,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
             transactionBuilder.Append(new DoNothing());
         }
 
-        var transaction = transactionBuilder.Build(default!, default);
+        var transaction = await transactionBuilder.BuildAsync(default!, default);
 
         // ASSERT
 
@@ -199,10 +199,10 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         // ACT
 
-        var transaction = transactionBuilder
+        var transaction = await transactionBuilder
             .Load(entity)
             .Append(new DoNothing())
-            .Build(default!, default);
+            .BuildAsync(default!, default);
 
         // ASSERT
 


### PR DESCRIPTION
In order to allow the agent signature augmenter to be asynchronous, the transaction builder needs to be asynchronous as well.

This PR changes the following:
1. `ITransaction TransactionBuilder.Build` -> `Task<ITransaction> TransactionBuilder.BuildAsync`
2. `ITransaction SingleEntityTransactionBuilder.Build` -> `Task<ITransaction> SingleEntityTransactionBuilder.BuildAsync`
3. `IAgent IAgentAccessor.GetAgent` -> `Task<IAgent> IAgentAccessor.GetAgentAsync`
4. `IAgent AgentAccessorBase.CreateAgent` -> `Task<IAgent> AgentAccessorBase.CreateAgentAsync`
5. `Dictionary<string, string> IAgentSignatureAugmenter.GetApplicationInfo` -> `Task<Dictionary<string, string>> IAgentSignatureAugmenter.GetApplicationInfo` (not suffixed with `Async` as all methods on this object are async, and I don't expect to add anything else to this interface)

The rest of the changes in this PR are a direct result of the changed mentioned above.