### PR TITLE
feat: required outer services for agent accessor chain

### DIFF
--- a/src/EntityDb.Common/Agents/AgentAccessorChain.cs
+++ b/src/EntityDb.Common/Agents/AgentAccessorChain.cs
@@ -21,11 +21,31 @@ public class AgentAccessorChain : IAgentAccessor
     private readonly IAgentAccessor[] _agentAccessors;
     
     /// <ignore/>
-    public AgentAccessorChain(ILogger<AgentAccessorChain> logger, IOptions<AgentAccessorChainOptions> options, IServiceProvider outerServiceProvider) : this(logger, options.Value, outerServiceProvider)
+    public AgentAccessorChain
+    (
+        ILogger<AgentAccessorChain> logger,
+        IOptions<AgentAccessorChainOptions> options,
+        IServiceProvider outerServiceProvider
+    ) : this(logger, options.Value, outerServiceProvider)
     {
     }
     
-    internal AgentAccessorChain(ILogger<AgentAccessorChain> logger, AgentAccessorChainOptions options, IServiceProvider outerServiceProvider)
+    internal AgentAccessorChain
+    (
+        ILogger<AgentAccessorChain> logger,
+        AgentAccessorChainOptions options,
+        IServiceProvider outerServiceProvider
+    )
+    {
+        var serviceProvider = GetServiceProvider(outerServiceProvider, options);
+        
+        _logger = logger;
+        _agentAccessors = serviceProvider
+            .GetServices<IAgentAccessor>()
+            .ToArray();
+    }
+
+    private static IServiceProvider GetServiceProvider(IServiceProvider outerServiceProvider, AgentAccessorChainOptions options)
     {
         IServiceCollection serviceCollectionCopy = new ServiceCollection();
 
@@ -44,12 +64,7 @@ public class AgentAccessorChain : IAgentAccessor
             serviceCollectionCopy.Add(serviceDescriptor);
         }
 
-        var serviceProvider = serviceCollectionCopy.BuildServiceProvider();
-        
-        _logger = logger;
-        _agentAccessors = serviceProvider
-            .GetServices<IAgentAccessor>()
-            .ToArray();
+        return serviceCollectionCopy.BuildServiceProvider();
     }
 
     /// <inheritdoc />

--- a/src/EntityDb.Common/Agents/AgentAccessorChainOptions.cs
+++ b/src/EntityDb.Common/Agents/AgentAccessorChainOptions.cs
@@ -1,5 +1,7 @@
 using EntityDb.Abstractions.Agents;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
 
 namespace EntityDb.Common.Agents;
 
@@ -9,7 +11,19 @@ namespace EntityDb.Common.Agents;
 public sealed class AgentAccessorChainOptions
 {
     /// <summary>
-    ///     A service collection used to resolve multiple instances of <see cref="IAgentAccessor"/>.
+    ///     An inner service collection used to configure and resolve multiple instances of <see cref="IAgentAccessor"/>.
     /// </summary>
     public IServiceCollection ServiceCollection { get; } = new ServiceCollection();
+
+    /// <summary>
+    ///     If any of the instances of <see cref="IAgentAccessor"/> which are added to <see cref="ServiceCollection"/>
+    ///     have required dependencies that live in the outer service provider (the one constructing <see cref="AgentAccessorChainOptions"/>),
+    ///     then you can specify them here.
+    /// </summary>
+    /// <remarks>
+    ///     Note that the <see cref="ServiceLifetime.Scoped">ServiceLifetime.Scoped</see> is not supported,
+    ///     and if the outer service is itself scoped, the agent accessor will not be able to receive it
+    ///     because it is, itself, registered as a singleton service.
+    /// </remarks>
+    public Dictionary<Type, ServiceLifetime> RequiredOuterServices { get; } = new();
 }


### PR DESCRIPTION
This feature allows access to required services from the service provider that constructed the agent accessor chain.

# Motivation 
#39 Overlooked the fact that the `HttpContextAgentAccessor` would no longer be able to access the `IHttpContextAccessor` which returns the `HttpContext` provided by the MVC package.

# Usage

As an example of how to use this for the `HttpContextAgentAccessor`, you would have something like the following:

```cs
serviceCollection.AddHttpContextAccessor();

serviceCollection.Configure<AgentAccessorChainOptions>(options =>
{
    // ... Configure HttpContextAgentAccessorOptions

    options.RequiredOuterServices.Add(typeof(IHttpContextAccessor), ServiceLifetime.Singleton);

    options.ServiceCollection.AddHttpContextAgentAccessor();

    // ... Add more Agent Accessors
});
```