### PR TITLE
feat: auto-tagging and auto-leasing

### DIFF
--- a/src/EntityDb.Common/Commands/IAddLeasesCommand.cs
+++ b/src/EntityDb.Common/Commands/IAddLeasesCommand.cs
@@ -1,0 +1,23 @@
+﻿using EntityDb.Abstractions.Leases;
+using EntityDb.Abstractions.ValueObjects;
+using EntityDb.Common.Transactions.Builders;
+using System.Collections.Generic;
+
+namespace EntityDb.Common.Commands;
+
+/// <summary>
+///     If a transaction needs to add any instances of <see cref="ILease"/>, and the properties of the leases
+///     are contained in the command and/or entity, a direct call to <see cref="TransactionBuilder{TEntity}.Add(Id, ILease[])"/>
+///     can be avoided by implementing this interface!
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity</typeparam>
+internal interface IAddLeasesCommand<in TEntity>
+{
+    /// <summary>
+    ///     Returns the leases that need to be added.
+    /// </summary>
+    /// <param name="previousEntity">The entity before this command was applied.</param>
+    /// <param name="nextEntity">The entity after this command was applied.</param>
+    /// <returns>The leases that need to be added.</returns>
+    IEnumerable<ILease> GetLeases(TEntity previousEntity, TEntity nextEntity);
+}

--- a/src/EntityDb.Common/Commands/IAddTagsCommand.cs
+++ b/src/EntityDb.Common/Commands/IAddTagsCommand.cs
@@ -1,0 +1,23 @@
+﻿using EntityDb.Abstractions.Tags;
+using EntityDb.Abstractions.ValueObjects;
+using EntityDb.Common.Transactions.Builders;
+using System.Collections.Generic;
+
+namespace EntityDb.Common.Commands;
+
+/// <summary>
+///     If a transaction needs to add any instances of <see cref="ITag"/>, and the properties of the tags
+///     are contained in the command and/or entity, a direct call to <see cref="TransactionBuilder{TEntity}.Add(Id, ITag[])"/>
+///     can be avoided by implementing this interface!
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity</typeparam>
+internal interface IAddTagsCommand<in TEntity>
+{
+    /// <summary>
+    ///     Returns the tags that need to be added.
+    /// </summary>
+    /// <param name="previousEntity">The entity before this command was applied.</param>
+    /// <param name="nextEntity">The entity after this command was applied.</param>
+    /// <returns>The tags that need to be added.</returns>
+    IEnumerable<ITag> GetTags(TEntity previousEntity, TEntity nextEntity);
+}

--- a/src/EntityDb.Common/Commands/IDeleteLeasesCommand.cs
+++ b/src/EntityDb.Common/Commands/IDeleteLeasesCommand.cs
@@ -1,0 +1,23 @@
+﻿using EntityDb.Abstractions.Leases;
+using EntityDb.Abstractions.ValueObjects;
+using EntityDb.Common.Transactions.Builders;
+using System.Collections.Generic;
+
+namespace EntityDb.Common.Commands;
+
+/// <summary>
+///     If a transaction needs to delete any instances of <see cref="ILease"/>, and the properties of the leases
+///     are contained in the command and/or entity, a direct call to <see cref="TransactionBuilder{TEntity}.Delete(Id, ILease[])"/>
+///     can be avoided by implementing this interface!
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity</typeparam>
+internal interface IDeleteLeasesCommand<in TEntity>
+{
+    /// <summary>
+    ///     Returns the leases that need to be deleted.
+    /// </summary>
+    /// <param name="previousEntity">The entity before this command was applied.</param>
+    /// <param name="nextEntity">The entity after this command was applied.</param>
+    /// <returns>The leases that need to be deleted.</returns>
+    IEnumerable<ILease> GetLeases(TEntity previousEntity, TEntity nextEntity);
+}

--- a/src/EntityDb.Common/Commands/IDeleteTagsCommand.cs
+++ b/src/EntityDb.Common/Commands/IDeleteTagsCommand.cs
@@ -1,0 +1,23 @@
+﻿using EntityDb.Abstractions.Tags;
+using EntityDb.Abstractions.ValueObjects;
+using EntityDb.Common.Transactions.Builders;
+using System.Collections.Generic;
+
+namespace EntityDb.Common.Commands;
+
+/// <summary>
+///     If a transaction needs to delete any instances of <see cref="ITag"/>, and the properties of the tags
+///     are contained in the command and/or entity, a direct call to <see cref="TransactionBuilder{TEntity}.Delete(Id, ITag[])"/>
+///     can be avoided by implementing this interface!
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity</typeparam>
+internal interface IDeleteTagsCommand<in TEntity>
+{
+    /// <summary>
+    ///     Returns the tags that need to be deleted.
+    /// </summary>
+    /// <param name="previousEntity">The entity before this command was applied.</param>
+    /// <param name="nextEntity">The entity after this command was applied.</param>
+    /// <returns>The tags that need to be deleted.</returns>
+    IEnumerable<ITag> GetTags(TEntity previousEntity, TEntity nextEntity);
+}


### PR DESCRIPTION
#26 removed a feature that I was quite fond of the idea of - that you can auto-tag and auto-lease an entity. While that PR had the right idea about how the transaction builder should work, it did not mean that auto-tagging and auto-leasing were completely off the table. This PR brings that feature back in a slightly altered format.

Where as before, you configured auto-tagging and auto-lasing at the entity level, you now do it at the command level.

Commands can optional implement any/all of the following interfaces:
1. `IAddLeasesCommand`
2. `IAddTagsCommand`
3. `IDeleteLeasesCommand`
4. `IDeleteTagsCommand`

Appending a command that implements any of these interfaces will not only add a `IAppendCommandTransactionStep` to a transaction's steps, but also the corresponding step(s) following, as is applicable:
1. `IAddLeasesTransactionStep`
2. `IAddTagsTransactionStep`
3. `IDeleteLeasesTransactionStep`
4. `IDeleteTagsTransactionStep`

The order that these are checked/added is as they are listed, but may be subject to change in the future if it is deemed necessary to do things in a particular order.