### PR TITLE
feat: pass entity to get projection ids

### DIFF
--- a/src/EntityDb.Abstractions/Projections/IProjectionStrategy.cs
+++ b/src/EntityDb.Abstractions/Projections/IProjectionStrategy.cs
@@ -18,10 +18,10 @@ public interface IProjectionStrategy<in TProjection>
     Task<Id[]> GetEntityIds(Id projectionId, TProjection projectionSnapshot);
 
     /// <summary>
-    ///     Map an entity id and/or the entity itself to a set of projection ids.
+    ///     Map an entity id and/or the entity itself to a projection id.
     /// </summary>
     /// <param name="entityId">The id of the entity.</param>
     /// <param name="entity">The entity.</param>
-    /// <returns>The set of projection ids to query for running the projection.</returns>
-    Task<Id[]> GetProjectionIds(Id entityId, object entity);
+    /// <returns>The projection id to query for running the projection.</returns>
+    Task<Id> GetProjectionId(Id entityId, object entity);
 }

--- a/src/EntityDb.Abstractions/Projections/IProjectionStrategy.cs
+++ b/src/EntityDb.Abstractions/Projections/IProjectionStrategy.cs
@@ -18,9 +18,10 @@ public interface IProjectionStrategy<in TProjection>
     Task<Id[]> GetEntityIds(Id projectionId, TProjection projectionSnapshot);
 
     /// <summary>
-    ///     Map an entity id to a set of projection ids.
+    ///     Map an entity id and/or the entity itself to a set of projection ids.
     /// </summary>
-    /// <param name="entityId">The id of th entity.</param>
+    /// <param name="entityId">The id of the entity.</param>
+    /// <param name="entity">The entity.</param>
     /// <returns>The set of projection ids to query for running the projection.</returns>
-    Task<Id[]> GetProjectionIds(Id entityId);
+    Task<Id[]> GetProjectionIds(Id entityId, object entity);
 }

--- a/src/EntityDb.Common/Entities/EntityRepository.cs
+++ b/src/EntityDb.Common/Entities/EntityRepository.cs
@@ -81,7 +81,7 @@ internal class EntityRepository<TEntity> : DisposableResourceBaseClass, IEntityR
     {
         await TransactionRepository.DisposeAsync();
 
-        if (SnapshotRepository != null)
+        if (SnapshotRepository is not null)
         {
             await SnapshotRepository.DisposeAsync();
         }
@@ -102,7 +102,7 @@ internal class EntityRepository<TEntity> : DisposableResourceBaseClass, IEntityR
         ISnapshotRepository<TEntity>? snapshotRepository = null
     )
     {
-        if (snapshotRepository == null)
+        if (snapshotRepository is null)
         {
             return ActivatorUtilities.CreateInstance<EntityRepository<TEntity>>(serviceProvider,
                 transactionRepository);

--- a/src/EntityDb.Common/Entities/EntityRepositoryFactory.cs
+++ b/src/EntityDb.Common/Entities/EntityRepositoryFactory.cs
@@ -32,7 +32,7 @@ internal class EntityRepositoryFactory<TEntity> : IEntityRepositoryFactory<TEnti
         var transactionRepository =
             await _transactionRepositoryFactory.CreateRepository(transactionSessionOptionsName, cancellationToken);
 
-        if (_snapshotRepositoryFactory == null || snapshotSessionOptionsName == null)
+        if (_snapshotRepositoryFactory is null || snapshotSessionOptionsName is null)
         {
             return EntityRepository<TEntity>.Create(_serviceProvider,
                 transactionRepository);

--- a/src/EntityDb.Common/Envelopes/EnvelopeHelper.cs
+++ b/src/EntityDb.Common/Envelopes/EnvelopeHelper.cs
@@ -59,14 +59,14 @@ internal static class EnvelopeHelper
         {
             var assemblyFullName = type.Assembly.FullName;
 
-            if (assemblyFullName != null)
+            if (assemblyFullName is not null)
             {
                 value.Add(AssemblyFullName, assemblyFullName);
             }
 
             var typeFullName = type.FullName;
 
-            if (typeFullName != null)
+            if (typeFullName is not null)
             {
                 value.Add(TypeFullName, typeFullName);
             }

--- a/src/EntityDb.Common/Extensions/SnapshotRepositoryExtensions.cs
+++ b/src/EntityDb.Common/Extensions/SnapshotRepositoryExtensions.cs
@@ -8,7 +8,7 @@ internal static class SnapshotRepositoryExtensions
 {
     public static async Task<TSnapshot?> GetSnapshotOrDefault<TSnapshot>(this ISnapshotRepository<TSnapshot>? snapshotRepository, Id snapshotId)
     {
-        if (snapshotRepository != null)
+        if (snapshotRepository is not null)
         {
             return await snapshotRepository.GetSnapshot(snapshotId);
         }

--- a/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
+++ b/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
@@ -32,7 +32,7 @@ internal class BulkOptimizedSnapshotRepository<TSnapshot> : DisposableResourceBa
 
         snapshot = await _snapshotRepository.GetSnapshot(snapshotId, cancellationToken);
 
-        if (snapshot != null)
+        if (snapshot is not null)
         {
             _cache[snapshotId] = snapshot;
         }

--- a/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
+++ b/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
@@ -48,6 +48,11 @@ internal class BulkOptimizedSnapshotRepository<TSnapshot> : DisposableResourceBa
         return Task.FromResult(false);
     }
 
+    public void CacheSnapshot(Id snapshotId, TSnapshot snapshot)
+    {
+        _getCache[snapshotId] = snapshot;
+    }
+
     public async Task<bool> PutSnapshots(CancellationToken cancellationToken = default)
     {
         foreach (var (snapshotId, snapshot) in _putCache)

--- a/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
+++ b/src/EntityDb.Common/Snapshots/BulkOptimizedSnapshotRepository.cs
@@ -1,0 +1,68 @@
+﻿using EntityDb.Abstractions.Snapshots;
+using EntityDb.Abstractions.ValueObjects;
+using EntityDb.Common.Disposables;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EntityDb.Common.Snapshots;
+
+internal class BulkOptimizedSnapshotRepository<TSnapshot> : DisposableResourceBaseClass, ISnapshotRepository<TSnapshot>
+{
+    private readonly Dictionary<Id, TSnapshot> _getCache = new();
+    private readonly Dictionary<Id, TSnapshot> _putCache = new();
+    private readonly ISnapshotRepository<TSnapshot> _snapshotRepository;
+
+    public BulkOptimizedSnapshotRepository(ISnapshotRepository<TSnapshot> snapshotRepository)
+    {
+        _snapshotRepository = snapshotRepository;
+    }
+
+    public Task<bool> DeleteSnapshots(Id[] snapshotIds, CancellationToken cancellationToken = default)
+    {
+        return _snapshotRepository.DeleteSnapshots(snapshotIds, cancellationToken);
+    }
+
+    public async Task<TSnapshot?> GetSnapshot(Id snapshotId, CancellationToken cancellationToken = default)
+    {
+        if (_getCache.TryGetValue(snapshotId, out var snapshot))
+        {
+            return snapshot;
+        }
+
+        snapshot = await _snapshotRepository.GetSnapshot(snapshotId, cancellationToken);
+
+        if (snapshot != null)
+        {
+            _getCache[snapshotId] = snapshot;
+        }
+
+        return snapshot;
+    }
+
+    public Task<bool> PutSnapshot(Id snapshotId, TSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        _getCache[snapshotId] = snapshot;
+        _putCache[snapshotId] = snapshot;
+
+        return Task.FromResult(false);
+    }
+
+    public async Task<bool> PutSnapshots(CancellationToken cancellationToken = default)
+    {
+        foreach (var (snapshotId, snapshot) in _putCache)
+        {
+            await _snapshotRepository.PutSnapshot(snapshotId, snapshot, cancellationToken);
+        }
+
+        return true;
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        _getCache.Clear();
+        _putCache.Clear();
+
+        return _snapshotRepository.DisposeAsync();
+    }
+}

--- a/src/EntityDb.Common/Transactions/EntitySnapshotTransactionSubscriber.cs
+++ b/src/EntityDb.Common/Transactions/EntitySnapshotTransactionSubscriber.cs
@@ -51,6 +51,10 @@ internal class EntitySnapshotTransactionSubscriber<TEntity> : TransactionSubscri
             {
                 await snapshotRepository.PutSnapshot(entityId, nextSnapshot);
             }
+            else
+            {
+                snapshotRepository.CacheSnapshot(entityId, nextSnapshot);
+            }
         }
 
         await snapshotRepository.PutSnapshots();

--- a/src/EntityDb.Common/Transactions/ProjectionSnapshotTransactionSubscriber.cs
+++ b/src/EntityDb.Common/Transactions/ProjectionSnapshotTransactionSubscriber.cs
@@ -52,7 +52,7 @@ internal class ProjectionSnapshotTransactionSubscriber<TProjection> : Transactio
                 continue;
             }
             
-            var projectionIds = await _projectionStrategy.GetProjectionIds(appendCommandTransactionStep.EntityId);
+            var projectionIds = await _projectionStrategy.GetProjectionIds(appendCommandTransactionStep.EntityId, appendCommandTransactionStep.Entity);
             
             foreach (var projectionId in projectionIds)
             {

--- a/src/EntityDb.Common/Transactions/ProjectionSnapshotTransactionSubscriber.cs
+++ b/src/EntityDb.Common/Transactions/ProjectionSnapshotTransactionSubscriber.cs
@@ -66,6 +66,10 @@ internal class ProjectionSnapshotTransactionSubscriber<TProjection> : Transactio
             {
                 await snapshotRepository.PutSnapshot(projectionId, nextSnapshot);
             }
+            else
+            {
+                snapshotRepository.CacheSnapshot(projectionId, nextSnapshot);
+            }
         }
 
         await snapshotRepository.PutSnapshots();

--- a/src/EntityDb.MongoDb.Provisioner/Commands/CreateCollections.cs
+++ b/src/EntityDb.MongoDb.Provisioner/Commands/CreateCollections.cs
@@ -37,7 +37,7 @@ internal class CreateCollections : CommandBase
 
         var cluster = await mongoDbAtlasClient.GetCluster(clusterName);
 
-        if (cluster == null || cluster.SrvAddress?.StartsWith(protocol) != true)
+        if (cluster is null || cluster.SrvAddress?.StartsWith(protocol) != true)
         {
             throw new InvalidOperationException();
         }

--- a/src/EntityDb.MongoDb.Provisioner/MongoDbAtlas/DigestChallengeRequest.cs
+++ b/src/EntityDb.MongoDb.Provisioner/MongoDbAtlas/DigestChallengeRequest.cs
@@ -62,7 +62,7 @@ internal record DigestChallengeRequest(string? Realm, string? Domain, string? No
     {
         digestChallengeRequest = default!;
 
-        if (authorizationHeaderValue.Scheme != "Digest" || authorizationHeaderValue.Parameter == null)
+        if (authorizationHeaderValue.Scheme != "Digest" || authorizationHeaderValue.Parameter is null)
         {
             return false;
         }

--- a/src/EntityDb.MongoDb/Extensions/DocumentQueryExtensions.cs
+++ b/src/EntityDb.MongoDb/Extensions/DocumentQueryExtensions.cs
@@ -59,7 +59,7 @@ internal static class DocumentQueryExtensions
 
         var document = documents.SingleOrDefault();
 
-        return document == null
+        return document is null
             ? default
             : document.EntityVersionNumber;
     }

--- a/src/EntityDb.MongoDb/Sessions/MongoSession.cs
+++ b/src/EntityDb.MongoDb/Sessions/MongoSession.cs
@@ -108,17 +108,17 @@ internal record MongoSession
             })
             .Project(projection);
 
-        if (sort != null)
+        if (sort is not null)
         {
             find = find.Sort(sort);
         }
 
-        if (skip != null)
+        if (skip is not null)
         {
             find = find.Skip(skip);
         }
 
-        if (limit != null)
+        if (limit is not null)
         {
             find = find.Limit(limit);
         }

--- a/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
+++ b/src/EntityDb.Mvc/Agents/HttpContextAgentAccessor.cs
@@ -31,7 +31,7 @@ internal sealed class HttpContextAgentAccessor : AgentAccessorBase
     {
         var httpContext = _httpContextAccessor.HttpContext;
 
-        if (httpContext == null)
+        if (httpContext is null)
         {
             throw new NoAgentException();
         }

--- a/test/EntityDb.Common.Tests/Entities/EntityTests.cs
+++ b/test/EntityDb.Common.Tests/Entities/EntityTests.cs
@@ -38,7 +38,7 @@ public class EntityTests : TestsBase<Startup>
             .GetRequiredService<TransactionBuilder<TestEntity>>()
             .ForSingleEntity(entityId);
 
-        if (entity != null)
+        if (entity is not null)
         {
             transactionBuilder.Load(entity);
         }

--- a/test/EntityDb.Common.Tests/Implementations/Entities/TestEntity.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Entities/TestEntity.cs
@@ -54,7 +54,7 @@ public record TestEntity
 
     public bool ShouldReplace(TestEntity? previousSnapshot)
     {
-        if (ShouldReplaceLogic.Value != null)
+        if (ShouldReplaceLogic.Value is not null)
         {
             return ShouldReplaceLogic.Value.Invoke(this, previousSnapshot);
         }

--- a/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjection.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjection.cs
@@ -48,7 +48,7 @@ public record OneToOneProjection
 
     public bool ShouldReplace(OneToOneProjection? previousSnapshot)
     {
-        if (ShouldReplaceLogic.Value != null)
+        if (ShouldReplaceLogic.Value is not null)
         {
             return ShouldReplaceLogic.Value.Invoke(this, previousSnapshot);
         }

--- a/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjectionStrategy.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjectionStrategy.cs
@@ -11,7 +11,7 @@ public class SingleEntityProjectionStrategy : IProjectionStrategy<OneToOneProjec
         return Task.FromResult(new[] { projectionId });
     }
 
-    public Task<Id[]> GetProjectionIds(Id entityId)
+    public Task<Id[]> GetProjectionIds(Id entityId, object entity)
     {
         return Task.FromResult(new[] { entityId });
     }

--- a/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjectionStrategy.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjectionStrategy.cs
@@ -11,8 +11,8 @@ public class SingleEntityProjectionStrategy : IProjectionStrategy<OneToOneProjec
         return Task.FromResult(new[] { projectionId });
     }
 
-    public Task<Id[]> GetProjectionIds(Id entityId, object entity)
+    public Task<Id> GetProjectionId(Id entityId, object entity)
     {
-        return Task.FromResult(new[] { entityId });
+        return Task.FromResult(entityId);
     }
 }

--- a/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
+++ b/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
@@ -174,7 +174,7 @@ public class ProjectionsTests : TestsBase<Startup>
             .GetMethod(nameof(Generic_GivenEmptyTransactionRepository_WhenGettingProjection_ThenReturnDefaultProjection), ~BindingFlags.Public)!
             .MakeGenericMethod(snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
 
     [Theory]
@@ -186,7 +186,7 @@ public class ProjectionsTests : TestsBase<Startup>
             .GetMethod(nameof(Generic_GivenProjectionStrategyReturnsNoEntityIds_WhenGettingProjection_ThenReturnDefaultProjection), ~BindingFlags.Public)!
             .MakeGenericMethod(snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
     
     [Theory]
@@ -197,6 +197,6 @@ public class ProjectionsTests : TestsBase<Startup>
             .GetMethod(nameof(Generic_GivenTransactionCommitted_WhenGettingProjection_ThenReturnExpectedProjection), ~BindingFlags.Public)!
             .MakeGenericMethod(transactionsAdder.EntityType, snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
 }

--- a/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
+++ b/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
@@ -61,7 +61,7 @@ public sealed class SnapshotTests : TestsBase<Startup>
             .GetMethod(nameof(GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched), ~BindingFlags.Public)!
             .MakeGenericMethod(snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
     
     private async Task GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged<TSnapshot>(SnapshotsAdder snapshotsAdder)
@@ -106,7 +106,7 @@ public sealed class SnapshotTests : TestsBase<Startup>
             .GetMethod(nameof(GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged), ~BindingFlags.Public)!
             .MakeGenericMethod(snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
 
     private async Task GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot<TSnapshot>(SnapshotsAdder snapshotsAdder)
@@ -162,6 +162,6 @@ public sealed class SnapshotTests : TestsBase<Startup>
             .GetMethod(nameof(GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot), ~BindingFlags.Public)!
             .MakeGenericMethod(snapshotsAdder.SnapshotType)
             .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
 }

--- a/test/EntityDb.Common.Tests/TestsBase.cs
+++ b/test/EntityDb.Common.Tests/TestsBase.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 using Xunit.DependencyInjection;
 using Xunit.DependencyInjection.Logging;
 using Xunit.Sdk;
+using Shouldly;
 
 namespace EntityDb.Common.Tests;
 
@@ -80,7 +81,7 @@ public class TestsBase<TStartup>
     {
         _configuration = startupServiceProvider.GetRequiredService<IConfiguration>();
         _testOutputHelperAccessor = startupServiceProvider.GetRequiredService<ITestOutputHelperAccessor>();
-        _test = (typeof(TestOutputHelper).GetField("test", ~BindingFlags.Public)!.GetValue(_testOutputHelperAccessor.Output) as ITest)!;
+        _test = (typeof(TestOutputHelper).GetField("test", ~BindingFlags.Public)!.GetValue(_testOutputHelperAccessor.Output) as ITest).ShouldNotBeNull();
     }
 
     private static readonly TransactionsAdder[] AllTransactionsAdders =

--- a/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
@@ -69,7 +69,7 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
             .GetMethod(nameof(Generic_GivenSnapshotShouldReplaceAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot), ~BindingFlags.Public)!
             .MakeGenericMethod(transactionsAdder.EntityType)
             .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
     
     private async Task
@@ -118,6 +118,6 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
             .GetMethod(nameof(Generic_GivenSnapshotShouldReplaceAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot), ~BindingFlags.Public)!
             .MakeGenericMethod(transactionsAdder.EntityType)
             .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>()!;
+            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
     }
 }

--- a/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
@@ -93,7 +93,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         transaction.Steps.Length.ShouldBe(1);
             
-        var leaseTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAddLeasesTransactionStep>()!;
+        var leaseTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAddLeasesTransactionStep>().ShouldNotBeNull();
 
         leaseTransactionStep.Leases.ShouldNotBeEmpty();
     }
@@ -168,7 +168,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         {
             var index = (int)(v.Value - 1);
 
-            var commandTransactionStep = transaction.Steps[index].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
+            var commandTransactionStep = transaction.Steps[index].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
             commandTransactionStep.EntityVersionNumber.ShouldBe(v);
         }
@@ -208,7 +208,7 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         transaction.Steps.Length.ShouldBe(1);
 
-        var commandTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
+        var commandTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
         commandTransactionStep.Command.ShouldBeEquivalentTo(new DoNothing());
     }

--- a/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
@@ -435,7 +435,7 @@ public sealed class TransactionTests : TestsBase<Startup>
             };
         }
 
-        if (agentSignatureOverride != null)
+        if (agentSignatureOverride is not null)
         {
             transaction = transaction with
             {

--- a/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
@@ -425,7 +425,7 @@ public sealed class TransactionTests : TestsBase<Startup>
             transactionBuilder.Add(new CountTag(count));
         }
 
-        var transaction = (transactionBuilder.Build(default!, transactionId) as Transaction)!;
+        var transaction = (transactionBuilder.Build(default!, transactionId) as Transaction).ShouldNotBeNull();
             
         if (timeStampOverride.HasValue)
         {
@@ -680,8 +680,8 @@ public sealed class TransactionTests : TestsBase<Startup>
         firstTransaction.Steps.ShouldAllBe(step => step.EntityId == entityId);
         secondTransaction.Steps.ShouldAllBe(step => step.EntityId == entityId);
         
-        var firstCommandTransactionStep = firstTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
-        var secondCommandTransactionStep = secondTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
+        var firstCommandTransactionStep = firstTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
+        var secondCommandTransactionStep = secondTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
         firstCommandTransactionStep.EntityVersionNumber.ShouldBe(secondCommandTransactionStep.EntityVersionNumber);
 
@@ -867,7 +867,7 @@ public sealed class TransactionTests : TestsBase<Startup>
         annotatedCommands[0].EntityId.ShouldBe(expectedEntityId);
         annotatedCommands[0].EntityVersionNumber.ShouldBe(new VersionNumber(1));
             
-        var actualCountCommand = annotatedCommands[0].Data.ShouldBeAssignableTo<Count>()!;
+        var actualCountCommand = annotatedCommands[0].Data.ShouldBeAssignableTo<Count>().ShouldNotBeNull();
 
         actualCountCommand.Number.ShouldBe(expectedCount);
             
@@ -1066,7 +1066,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         transaction.Steps.Length.ShouldBe(1);
 
-        var commandTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
+        var commandTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
         commandTransactionStep.EntityVersionNumber.ShouldBe(new VersionNumber(1));
 
@@ -1124,7 +1124,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         secondTransaction.Steps.Length.ShouldBe(1);
 
-        var secondCommandTransactionStep = secondTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>()!;
+        var secondCommandTransactionStep = secondTransaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
         secondCommandTransactionStep.EntityVersionNumber.ShouldBe(new VersionNumber(2));
 


### PR DESCRIPTION
Consider the following graph:

```mermaid
graph BT
    Leaf1 --> Branch1
    Leaf2 --> Branch1
    Leaf3 --> Branch2
    Leaf4 --> Branch2
    Branch1 --> Root1
    Branch2 --> Root1
```

It has a tree-like structure that you will probably find in most bounded contexts in some shape or form. As of #29 you can represent each of these nodes as an entity in a single transaction repository.


If each branch node's entity has the `Id` of every ancestor node's entity, this change allows you to easily build a projection of the entire tree.

When the `ProjectionSnapshotTransactionSubscriber` runs, it will not have to run queries to get the ancestor node's entity ids.. you can just check what kind of object the entity is and pull the appropriate property.

The following partial code could be used to map all of these entities to a single projection.

```cs
public record Leaf(Id RootId, Id BranchId, Id LeafId, ...);
```
```cs
public record Branch(Id RootId, Id BranchId, ...);
```
```cs
public record Root(Id RootId, ...);
```
```cs
public class RootGraphProjectionStrategy : IProjectionStrategy<RootGraph>
{
    public Id[] GetProjectionIds(Id entityId, object entity)
    {
        if (entity is Leaf leaf) {
            return new[] { leaf.RootId };
        }

        if (entity is Branch branch) {
            return new[] { branch.RootId };
        }

        if (entity is Root root) {
            return new[] { root.RootId };
        }

        throw new NotSupportedException();
    }
}
```

# Note
I recommend against storing the _entire data model_ in one repository - you should probably stick to a repository per bounded context - but there is no reason a bounded context must only own a single entity, and therefore there is no reason the transaction repository must only contain a single entity type! When it comes to APIs for accessing the graph of data - obviously GraphQL seems like a great idea, and the concept of [schema stitching and linking](https://www.apollographql.com/blog/backend/graphql-schema-stitching/) seems very promising.