### PR TITLE
Refactor: Better Tests

### DIFF
--- a/EntityDb.sln
+++ b/EntityDb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30105.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{ABACFBCC-B59F-4616-B6CC-99C37AEC8960}"
 	ProjectSection(SolutionItems) = preProject
@@ -25,6 +25,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{92484C44-2754-4C1D-BD46-98D83E4020EE}"
 	ProjectSection(SolutionItems) = preProject
 		test\Directory.Build.props = test\Directory.Build.props
+		test\docker-compose.yml = test\docker-compose.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityDb.Common.Tests", "test\EntityDb.Common.Tests\EntityDb.Common.Tests.csproj", "{CF316519-525E-4A67-BF12-1FDDF802B878}"

--- a/test/EntityDb.Common.Tests/Entities/EntityTests.cs
+++ b/test/EntityDb.Common.Tests/Entities/EntityTests.cs
@@ -58,7 +58,7 @@ public class EntityTests : TestsBase<Startup>
 
     [Theory]
     [MemberData(nameof(AddTransactionsAndEntitySnapshots))]
-    public async Task GivenEntityWithNVersions_WhenGettingAtVersionM_ThenReturnAtVersionM(TransactionsAdder transactionsAdder, SnapshotsAdder entitySnapshotsAdder)
+    public async Task GivenEntityWithNVersions_WhenGettingAtVersionM_ThenReturnAtVersionM(TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
     {
         // ARRANGE
 
@@ -71,8 +71,8 @@ public class EntityTests : TestsBase<Startup>
         
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
-            entitySnapshotsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
+            entitySnapshotAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();

--- a/test/EntityDb.Common.Tests/Entities/EntityTests.cs
+++ b/test/EntityDb.Common.Tests/Entities/EntityTests.cs
@@ -16,6 +16,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EntityDb.Abstractions.ValueObjects;
 using Xunit;
+using EntityDb.Common.Entities;
+using EntityDb.Common.Tests.Implementations.Snapshots;
 
 namespace EntityDb.Common.Tests.Entities;
 
@@ -25,17 +27,18 @@ public class EntityTests : TestsBase<Startup>
     {
     }
 
-    private static ITransaction BuildTransaction
+    private static ITransaction BuildTransaction<TEntity>
     (
         IServiceScope serviceScope,
         Id entityId,
         VersionNumber from,
         VersionNumber to,
-        TestEntity? entity = null
+        TEntity? entity = default
     )
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(entityId);
 
         if (entity is not null)
@@ -56,19 +59,19 @@ public class EntityTests : TestsBase<Startup>
         return transactionBuilder.Build(default!, Id.NewId());
     }
 
-    [Theory]
-    [MemberData(nameof(AddTransactionsAndEntitySnapshots))]
-    public async Task GivenEntityWithNVersions_WhenGettingAtVersionM_ThenReturnAtVersionM(TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
+
+    private async Task Generic_GivenEntityWithNVersions_WhenGettingAtVersionM_ThenReturnAtVersionM<TEntity>(TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
         const ulong n = 10UL;
         const ulong m = 5UL;
-        
+
         var versionNumberN = new VersionNumber(n);
 
         var versionNumberM = new VersionNumber(m);
-        
+
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
             transactionsAdder.AddDependencies.Invoke(serviceCollection);
@@ -78,11 +81,11 @@ public class EntityTests : TestsBase<Startup>
         var entityId = Id.NewId();
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository(TestSessionOptions.Write,
                 TestSessionOptions.Write);
 
-        var transaction = BuildTransaction(serviceScope, entityId, new VersionNumber(1), versionNumberN);
+        var transaction = BuildTransaction<TEntity>(serviceScope, entityId, new VersionNumber(1), versionNumberN);
 
         var transactionInserted = await entityRepository.PutTransaction(transaction);
 
@@ -99,8 +102,8 @@ public class EntityTests : TestsBase<Startup>
         entityAtVersionM.VersionNumber.ShouldBe(versionNumberM);
     }
 
-    [Fact]
-    public async Task GivenExistingEntityWithNoSnapshot_WhenGettingEntity_ThenGetCommandsRuns()
+    private async Task Generic_GivenExistingEntityWithNoSnapshot_WhenGettingEntity_ThenGetCommandsRuns<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
@@ -145,14 +148,16 @@ public class EntityTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(transactionRepositoryFactoryMock.Object);
         });
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository(TestSessionOptions.Write);
 
-        var transaction = BuildTransaction(serviceScope, entityId, new VersionNumber(1), expectedVersionNumber);
+        var transaction = BuildTransaction<TEntity>(serviceScope, entityId, new VersionNumber(1), expectedVersionNumber);
 
         var transactionInserted = await entityRepository.PutTransaction(transaction);
 
@@ -172,23 +177,25 @@ public class EntityTests : TestsBase<Startup>
             .Verify(repository => repository.GetCommands(It.IsAny<ICommandQuery>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact]
-    public async Task GivenNoSnapshotRepositoryFactory_WhenCreatingEntityRepository_ThenNoSnapshotRepository()
+    private async Task Generic_GivenNoSnapshotRepositoryFactory_WhenCreatingEntityRepository_ThenNoSnapshotRepository<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(GetMockedTransactionRepositoryFactory());
         });
 
         // ACT
 
-        var snapshotRepositoryFactory = serviceScope.ServiceProvider
-            .GetService<ISnapshotRepositoryFactory<TestEntity>>();
+        await using var snapshotRepositoryFactory = serviceScope.ServiceProvider
+            .GetService<ISnapshotRepositoryFactory<TEntity>>();
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository("NOT NULL", "NOT NULL");
 
         // ASSERT
@@ -198,24 +205,26 @@ public class EntityTests : TestsBase<Startup>
         entityRepository.SnapshotRepository.ShouldBeNull();
     }
 
-    [Fact]
-    public async Task GivenNoSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository()
+    private async Task Generic_GivenNoSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(GetMockedTransactionRepositoryFactory());
-            serviceCollection.AddSingleton(GetMockedSnapshotRepositoryFactory());
+            serviceCollection.AddSingleton(GetMockedSnapshotRepositoryFactory<TEntity>());
         });
 
         // ACT
 
-        var snapshotRepositoryFactory = serviceScope.ServiceProvider
-            .GetService<ISnapshotRepositoryFactory<TestEntity>>();
+        await using var snapshotRepositoryFactory = serviceScope.ServiceProvider
+            .GetService<ISnapshotRepositoryFactory<TEntity>>();
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository("NOT NULL");
 
         // ASSERT
@@ -225,24 +234,26 @@ public class EntityTests : TestsBase<Startup>
         entityRepository.SnapshotRepository.ShouldBeNull();
     }
 
-    [Fact]
-    public async Task GivenSnapshotRepositoryFactoryAndSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository()
+    private async Task Generic_GivenSnapshotRepositoryFactoryAndSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(GetMockedTransactionRepositoryFactory());
-            serviceCollection.AddSingleton(GetMockedSnapshotRepositoryFactory());
+            serviceCollection.AddSingleton(GetMockedSnapshotRepositoryFactory<TEntity>());
         });
 
         // ACT
 
-        var snapshotRepositoryFactory = serviceScope.ServiceProvider
-            .GetService<ISnapshotRepositoryFactory<TestEntity>>();
+        await using var snapshotRepositoryFactory = serviceScope.ServiceProvider
+            .GetService<ISnapshotRepositoryFactory<TEntity>>();
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository("NOT NULL", "NOT NULL");
 
         // ASSERT
@@ -252,12 +263,12 @@ public class EntityTests : TestsBase<Startup>
         entityRepository.SnapshotRepository.ShouldNotBeNull();
     }
 
-    [Fact]
-    public async Task GivenSnapshotAndNewCommands_WhenGettingSnapshotOrDefault_ThenReturnNewerThanSnapshot()
+    private async Task Generic_GivenSnapshotAndNewCommands_WhenGettingSnapshotOrDefault_ThenReturnNewerThanSnapshot<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
-        var snapshot = new TestEntity(default, new VersionNumber(1));
+        var snapshot = TEntity.Construct(default).WithVersionNumber(new VersionNumber(1));
 
         var newCommands = new object[]
         {
@@ -267,6 +278,8 @@ public class EntityTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(GetMockedTransactionRepositoryFactory(newCommands));
             serviceCollection.AddSingleton(GetMockedSnapshotRepositoryFactory(snapshot));
         });
@@ -274,7 +287,7 @@ public class EntityTests : TestsBase<Startup>
         // ACT
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository("NOT NULL", "NOT NULL");
 
         var snapshotOrDefault = await entityRepository.GetSnapshot(default);
@@ -286,18 +299,20 @@ public class EntityTests : TestsBase<Startup>
         snapshotOrDefault.VersionNumber.ShouldBe(new VersionNumber(snapshot.VersionNumber.Value + Convert.ToUInt64(newCommands.Length)));
     }
 
-    [Fact]
-    public async Task GivenNonExistentEntityId_WhenGettingCurrentEntity_ThenThrow()
+    private async Task Generic_GivenNonExistentEntityId_WhenGettingCurrentEntity_ThenThrow<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddSingleton(GetMockedTransactionRepositoryFactory());
         });
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository(default!);
 
         // ASSERT
@@ -306,5 +321,82 @@ public class EntityTests : TestsBase<Startup>
         {
             await entityRepository.GetSnapshot(default);
         });
+    }
+
+    [Theory]
+    [MemberData(nameof(AddTransactionsAndEntitySnapshots))]
+    public Task GivenEntityWithNVersions_WhenGettingAtVersionM_ThenReturnAtVersionM(TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entitySnapshotAdder.SnapshotType },
+            new object?[] { transactionsAdder, entitySnapshotAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenExistingEntityWithNoSnapshot_WhenGettingEntity_ThenGetCommandsRuns(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenNoSnapshotRepositoryFactory_WhenCreatingEntityRepository_ThenNoSnapshotRepository(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenNoSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenSnapshotRepositoryFactoryAndSnapshotSessionOptions_WhenCreatingEntityRepository_ThenNoSnapshotRepository(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenSnapshotAndNewCommands_WhenGettingSnapshotOrDefault_ThenReturnNewerThanSnapshot(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenNonExistentEntityId_WhenGettingCurrentEntity_ThenThrow(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
     }
 }

--- a/test/EntityDb.Common.Tests/Implementations/Entities/IEntityWithVersionNumber.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Entities/IEntityWithVersionNumber.cs
@@ -1,8 +1,0 @@
-using EntityDb.Abstractions.ValueObjects;
-
-namespace EntityDb.Common.Tests.Implementations.Entities;
-
-public interface IEntityWithVersionNumber<TEntity>
-{
-    static abstract TEntity Construct(Id id, VersionNumber versionNumber);
-}

--- a/test/EntityDb.Common.Tests/Implementations/Entities/TestEntity.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Entities/TestEntity.cs
@@ -13,10 +13,9 @@ public record TestEntity
     Id Id,
     VersionNumber VersionNumber = default
 )
-: IEntity<TestEntity>, ISnapshotWithTestMethods<TestEntity>
+: IEntity<TestEntity>, ISnapshotWithTestLogic<TestEntity>
 {
-    public const string MongoCollectionName = "Test";
-    public const string RedisKeyNamespace = "test-entity";
+    public static string RedisKeyNamespace => "test-entity";
 
     public static TestEntity Construct(Id entityId)
     {

--- a/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjection.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Projections/OneToOneProjection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using EntityDb.Abstractions.Annotations;
@@ -17,9 +18,9 @@ public record OneToOneProjection
     Id Id,
     VersionNumber VersionNumber = default,
     VersionNumber EntityVersionNumber = default
-) : IProjection<OneToOneProjection>, ISnapshotWithTestMethods<OneToOneProjection>
+) : IProjection<OneToOneProjection>, ISnapshotWithTestLogic<OneToOneProjection>
 {
-    public const string RedisKeyNamespace = "one-to-one-projection";
+    public static string RedisKeyNamespace => "one-to-one-projection";
     
     public static OneToOneProjection Construct(Id projectionId)
     {

--- a/test/EntityDb.Common.Tests/Implementations/Seeders/TransactionSeeder.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Seeders/TransactionSeeder.cs
@@ -15,7 +15,7 @@ namespace EntityDb.Common.Tests.Implementations.Seeders;
 public static class TransactionStepSeeder
 {
     public static IEnumerable<ITransactionStep> CreateFromCommands<TEntity>(Id entityId, uint numCommands)
-        where TEntity : IEntity<TEntity>, ISnapshotWithTestMethods<TEntity>
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         for (var previousVersionNumber = new VersionNumber(0); previousVersionNumber.Value < numCommands; previousVersionNumber = previousVersionNumber.Next())
         {
@@ -47,7 +47,7 @@ public static class TransactionSeeder
     }
 
     public static ITransaction Create<TEntity>(Id entityId, uint numCommands)
-        where TEntity : IEntity<TEntity>, ISnapshotWithTestMethods<TEntity>
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         var transactionSteps = TransactionStepSeeder.CreateFromCommands<TEntity>(entityId, numCommands).ToArray();
 

--- a/test/EntityDb.Common.Tests/Implementations/Snapshots/ISnapshotWithTestLogic.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Snapshots/ISnapshotWithTestLogic.cs
@@ -5,9 +5,10 @@ using EntityDb.Common.Snapshots;
 
 namespace EntityDb.Common.Tests.Implementations.Snapshots;
 
-public interface ISnapshotWithTestMethods<TSnapshot> : ISnapshot<TSnapshot>
+public interface ISnapshotWithTestLogic<TSnapshot> : ISnapshot<TSnapshot>
 {
     TSnapshot WithVersionNumber(VersionNumber versionNumber);
+    static abstract string RedisKeyNamespace { get; }
     static abstract AsyncLocal<Func<TSnapshot, bool>?> ShouldRecordLogic { get; }
     static abstract AsyncLocal<Func<TSnapshot, TSnapshot?, bool>?> ShouldRecordAsLatestLogic { get; }
 }

--- a/test/EntityDb.Common.Tests/Implementations/Snapshots/ISnapshotWithTestLogic.cs
+++ b/test/EntityDb.Common.Tests/Implementations/Snapshots/ISnapshotWithTestLogic.cs
@@ -7,6 +7,7 @@ namespace EntityDb.Common.Tests.Implementations.Snapshots;
 
 public interface ISnapshotWithTestLogic<TSnapshot> : ISnapshot<TSnapshot>
 {
+    VersionNumber VersionNumber { get; }
     TSnapshot WithVersionNumber(VersionNumber versionNumber);
     static abstract string RedisKeyNamespace { get; }
     static abstract AsyncLocal<Func<TSnapshot, bool>?> ShouldRecordLogic { get; }

--- a/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
+++ b/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
@@ -93,7 +93,10 @@ public class ProjectionsTests : TestsBase<Startup>
         // ASSERT
         
         currentProjection.GetVersionNumber().Value.ShouldBe(numberOfVersionNumbers);
-        projectionSnapshot.ShouldNotBeNull().GetVersionNumber().Value.ShouldBe(replaceAtVersionNumber);
+
+        projectionSnapshot.ShouldNotBe(default);
+
+        projectionSnapshot!.GetVersionNumber().Value.ShouldBe(replaceAtVersionNumber);
     }
 
     [Theory]

--- a/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
+++ b/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
@@ -37,7 +37,7 @@ public class ProjectionsTests : TestsBase<Startup>
         });
 
         await using var projectionRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IProjectionRepositoryFactory<OneToOneProjection>>()
+            .GetRequiredService<IProjectionRepositoryFactory<TProjection>>()
             .CreateRepository(TestSessionOptions.Write, TestSessionOptions.Write, default);
         
         // ACT & ASSERT
@@ -72,7 +72,7 @@ public class ProjectionsTests : TestsBase<Startup>
             .CreateRepository(TestSessionOptions.Write);
         
         await using var projectionRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IProjectionRepositoryFactory<OneToOneProjection>>()
+            .GetRequiredService<IProjectionRepositoryFactory<TProjection>>()
             .CreateRepository(TestSessionOptions.Write, TestSessionOptions.Write, default);
 
         var transactionInserted = await entityRepository.PutTransaction(transaction);

--- a/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
+++ b/test/EntityDb.Common.Tests/Projections/ProjectionsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using EntityDb.Abstractions.Entities;
 using EntityDb.Abstractions.Projections;
@@ -103,7 +102,6 @@ public class ProjectionsTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEmptyTransactionRepository_WhenGettingProjection_ThenThrow),
             new[] { projectionSnapshotAdder.SnapshotType },
             new object?[] { transactionsAdder, entitySnapshotAdder, projectionSnapshotAdder }
         );
@@ -115,7 +113,6 @@ public class ProjectionsTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionCommitted_WhenGettingProjection_ThenReturnExpectedProjection),
             new[] { entitySnapshotAdder.SnapshotType, projectionSnapshotAdder.SnapshotType },
             new object?[] { transactionsAdder, entitySnapshotAdder, projectionSnapshotAdder }
         );

--- a/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
+++ b/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
@@ -21,7 +21,7 @@ public sealed class SnapshotTests : TestsBase<Startup>
     {
     }
 
-    private async Task GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched<TSnapshot>(SnapshotAdder snapshotAdder)
+    private async Task Generic_GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched<TSnapshot>(SnapshotAdder snapshotAdder)
         where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
@@ -56,17 +56,17 @@ public sealed class SnapshotTests : TestsBase<Startup>
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
     [MemberData(nameof(AddProjectionSnapshots))]
-    public Task GivenSnapshotsAdder_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched(SnapshotAdder snapshotAdder)
+    public Task GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched(SnapshotAdder snapshotAdder)
     {
         return RunGenericTestAsync
         (
-            nameof(GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched),
+            nameof(Generic_GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );
     }
     
-    private async Task GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged<TSnapshot>(SnapshotAdder snapshotAdder)
+    private async Task Generic_GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged<TSnapshot>(SnapshotAdder snapshotAdder)
         where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
@@ -102,17 +102,17 @@ public sealed class SnapshotTests : TestsBase<Startup>
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
     [MemberData(nameof(AddProjectionSnapshots))]
-    public Task GivenSnapshotsAdder_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged(SnapshotAdder snapshotAdder)
+    public Task GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged(SnapshotAdder snapshotAdder)
     {
         return RunGenericTestAsync
         (
-            nameof(GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged),
+            nameof(Generic_GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );
     }
 
-    private async Task GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot<TSnapshot>(SnapshotAdder snapshotAdder)
+    private async Task Generic_GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot<TSnapshot>(SnapshotAdder snapshotAdder)
         where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
@@ -159,11 +159,11 @@ public sealed class SnapshotTests : TestsBase<Startup>
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
     [MemberData(nameof(AddProjectionSnapshots))]
-    public Task GivenSnapshotsAdder_WhenReadingInsertedSnapshotInVariousReadModes_ThenReturnSameSnapshot(SnapshotAdder snapshotAdder)
+    public Task GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot(SnapshotAdder snapshotAdder)
     {
         return RunGenericTestAsync
         (
-            nameof(GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot),
+            nameof(Generic_GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );

--- a/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
+++ b/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
@@ -21,14 +21,14 @@ public sealed class SnapshotTests : TestsBase<Startup>
     {
     }
 
-    private async Task GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched<TSnapshot>(SnapshotsAdder snapshotsAdder)
-        where TSnapshot : ISnapshotWithTestMethods<TSnapshot>
+    private async Task GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched<TSnapshot>(SnapshotAdder snapshotAdder)
+        where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            snapshotsAdder.Add(serviceCollection);
+            snapshotAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var snapshotId = Id.NewId();
@@ -55,18 +55,19 @@ public sealed class SnapshotTests : TestsBase<Startup>
 
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
-    [MemberData(nameof(AddOneToOneProjectionSnapshots))]
-    public async Task GivenSnapshotsAdder_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched(SnapshotsAdder snapshotsAdder)
+    [MemberData(nameof(AddProjectionSnapshots))]
+    public Task GivenSnapshotsAdder_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched(SnapshotAdder snapshotAdder)
     {
-        await GetType()
-            .GetMethod(nameof(GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched), ~BindingFlags.Public)!
-            .MakeGenericMethod(snapshotsAdder.SnapshotType)
-            .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
+        return RunGenericTestAsync
+        (
+            nameof(GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched),
+            new[] { snapshotAdder.SnapshotType },
+            new object?[] { snapshotAdder }
+        );
     }
     
-    private async Task GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged<TSnapshot>(SnapshotsAdder snapshotsAdder)
-        where TSnapshot : ISnapshotWithTestMethods<TSnapshot>
+    private async Task GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged<TSnapshot>(SnapshotAdder snapshotAdder)
+        where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
 
@@ -74,7 +75,7 @@ public sealed class SnapshotTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            snapshotsAdder.Add(serviceCollection);
+            snapshotAdder.AddDependencies.Invoke(serviceCollection);
             
             serviceCollection.RemoveAll(typeof(ILoggerFactory));
 
@@ -100,18 +101,19 @@ public sealed class SnapshotTests : TestsBase<Startup>
     
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
-    [MemberData(nameof(AddOneToOneProjectionSnapshots))]
-    public async Task GivenSnapshotsAdder_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged(SnapshotsAdder snapshotsAdder)
+    [MemberData(nameof(AddProjectionSnapshots))]
+    public Task GivenSnapshotsAdder_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged(SnapshotAdder snapshotAdder)
     {
-        await GetType()
-            .GetMethod(nameof(GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged), ~BindingFlags.Public)!
-            .MakeGenericMethod(snapshotsAdder.SnapshotType)
-            .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
+        return RunGenericTestAsync
+        (
+            nameof(GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged),
+            new[] { snapshotAdder.SnapshotType },
+            new object?[] { snapshotAdder }
+        );
     }
 
-    private async Task GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot<TSnapshot>(SnapshotsAdder snapshotsAdder)
-        where TSnapshot : ISnapshotWithTestMethods<TSnapshot>
+    private async Task GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot<TSnapshot>(SnapshotAdder snapshotAdder)
+        where TSnapshot : ISnapshotWithTestLogic<TSnapshot>
     {
         // ARRANGE
 
@@ -121,7 +123,7 @@ public sealed class SnapshotTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            snapshotsAdder.Add(serviceCollection);
+            snapshotAdder.AddDependencies.Invoke(serviceCollection);
         });
         
         await using var writeSnapshotRepository = await serviceScope.ServiceProvider
@@ -156,13 +158,14 @@ public sealed class SnapshotTests : TestsBase<Startup>
     
     [Theory]
     [MemberData(nameof(AddEntitySnapshots))]
-    [MemberData(nameof(AddOneToOneProjectionSnapshots))]
-    public async Task GivenSnapshotsAdder_WhenReadingInsertedSnapshotInVariousReadModes_ThenReturnSameSnapshot(SnapshotsAdder snapshotsAdder)
+    [MemberData(nameof(AddProjectionSnapshots))]
+    public Task GivenSnapshotsAdder_WhenReadingInsertedSnapshotInVariousReadModes_ThenReturnSameSnapshot(SnapshotAdder snapshotAdder)
     {
-        await GetType()
-            .GetMethod(nameof(GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot), ~BindingFlags.Public)!
-            .MakeGenericMethod(snapshotsAdder.SnapshotType)
-            .Invoke(this, new object?[] { snapshotsAdder })
-            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
+        return RunGenericTestAsync
+        (
+            nameof(GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot),
+            new[] { snapshotAdder.SnapshotType },
+            new object?[] { snapshotAdder }
+        );
     }
 }

--- a/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
+++ b/test/EntityDb.Common.Tests/Snapshots/SnapshotTests.cs
@@ -60,7 +60,6 @@ public sealed class SnapshotTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEmptySnapshotRepository_WhenSnapshotInsertedAndFetched_ThenInsertedMatchesFetched),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );
@@ -106,7 +105,6 @@ public sealed class SnapshotTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEmptySnapshotRepository_WhenPuttingSnapshotInReadOnlyMode_ThenCannotWriteInReadOnlyModeExceptionIsLogged),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );
@@ -163,7 +161,6 @@ public sealed class SnapshotTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenInsertedSnapshot_WhenReadInVariousReadModes_ThenReturnSameSnapshot),
             new[] { snapshotAdder.SnapshotType },
             new object?[] { snapshotAdder }
         );

--- a/test/EntityDb.Common.Tests/Snapshots/TryCatchSnapshotRepositoryTests.cs
+++ b/test/EntityDb.Common.Tests/Snapshots/TryCatchSnapshotRepositoryTests.cs
@@ -28,14 +28,14 @@ public class TryCatchSnapshotRepositoryTests : TestsBase<Startup>
 
         var (loggerFactory, loggerVerifier) = GetMockedLoggerFactory<Exception>();
 
-        var snapshotRepositoryMock = new Mock<ISnapshotRepository<TestEntity>>(MockBehavior.Strict);
+        var snapshotRepositoryMock = new Mock<ISnapshotRepository<TEntity>>(MockBehavior.Strict);
 
         snapshotRepositoryMock
             .Setup(repository => repository.GetSnapshotOrDefault(It.IsAny<Pointer>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new NotImplementedException());
 
         snapshotRepositoryMock
-            .Setup(repository => repository.PutSnapshot(It.IsAny<Pointer>(), It.IsAny<TestEntity>(), It.IsAny<CancellationToken>()))
+            .Setup(repository => repository.PutSnapshot(It.IsAny<Pointer>(), It.IsAny<TEntity>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new NotImplementedException());
 
         snapshotRepositoryMock
@@ -51,7 +51,7 @@ public class TryCatchSnapshotRepositoryTests : TestsBase<Startup>
             serviceCollection.AddSingleton(loggerFactory);
         });
 
-        var tryCatchSnapshotRepository = TryCatchSnapshotRepository<TestEntity>
+        var tryCatchSnapshotRepository = TryCatchSnapshotRepository<TEntity>
             .Create(serviceScope.ServiceProvider, snapshotRepositoryMock.Object);
 
         // ACT

--- a/test/EntityDb.Common.Tests/StartupBase.cs
+++ b/test/EntityDb.Common.Tests/StartupBase.cs
@@ -25,10 +25,6 @@ public abstract class StartupBase : IStartup
 
         serviceCollection.AddAgentAccessor<UnknownAgentAccessor>();
 
-        // Transaction Entity
-
-        serviceCollection.AddEntity<TestEntity>();
-
         // Snapshot Session Options
 
         serviceCollection.Configure<SnapshotSessionOptions>(TestSessionOptions.Write, options =>

--- a/test/EntityDb.Common.Tests/TestsBase.cs
+++ b/test/EntityDb.Common.Tests/TestsBase.cs
@@ -68,6 +68,10 @@ public class TestsBase<TStartup>
 
     protected Task RunGenericTestAsync(string methodName, Type[] typeArguments, object?[] invokeParameters)
     {
+        var expectedMethodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
+
+        methodName.ShouldBe(expectedMethodName);
+
         var testTask = GetType()
             .GetMethod(methodName, ~BindingFlags.Public)?
             .MakeGenericMethod(typeArguments)

--- a/test/EntityDb.Common.Tests/TestsBase.cs
+++ b/test/EntityDb.Common.Tests/TestsBase.cs
@@ -75,11 +75,9 @@ public class TestsBase<TStartup>
     private readonly ITestOutputHelperAccessor _testOutputHelperAccessor;
     private readonly ITest _test;
 
-    protected Task RunGenericTestAsync(string methodName, Type[] typeArguments, object?[] invokeParameters)
+    protected Task RunGenericTestAsync(Type[] typeArguments, object?[] invokeParameters)
     {
-        var expectedMethodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
-
-        methodName.ShouldBe(expectedMethodName);
+        var methodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
 
         var testTask = GetType()
             .GetMethod(methodName, ~BindingFlags.Public)?

--- a/test/EntityDb.Common.Tests/TestsBase.cs
+++ b/test/EntityDb.Common.Tests/TestsBase.cs
@@ -101,19 +101,6 @@ public class TestsBase<TStartup>
             .ShouldBeAssignableTo<Task>()
             .ShouldNotBeNull();
     }
-    protected Task RunGenericTestAsync2(Func<Task> foo, Type[] typeArguments, object?[] invokeParameters)
-    {
-        var methodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
-
-        var methodOutput = GetType()
-            .GetMethod(methodName, ~BindingFlags.Public)?
-            .MakeGenericMethod(typeArguments)
-            .Invoke(this, invokeParameters);
-
-        return methodOutput
-            .ShouldBeAssignableTo<Task>()
-            .ShouldNotBeNull();
-    }
 
     protected TestsBase(IServiceProvider startupServiceProvider)
     {

--- a/test/EntityDb.Common.Tests/TestsBase.cs
+++ b/test/EntityDb.Common.Tests/TestsBase.cs
@@ -75,16 +75,30 @@ public class TestsBase<TStartup>
     private readonly ITestOutputHelperAccessor _testOutputHelperAccessor;
     private readonly ITest _test;
 
-    protected Task RunGenericTestAsync(Type[] typeArguments, object?[] invokeParameters)
+
+    protected void RunGenericTest(Type[] typeArguments, object?[] invokeParameters)
     {
         var methodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
 
-        var testTask = GetType()
+        var methodOutput = GetType()
             .GetMethod(methodName, ~BindingFlags.Public)?
             .MakeGenericMethod(typeArguments)
             .Invoke(this, invokeParameters);
 
-        return testTask
+        methodOutput
+            .ShouldBeNull();
+    }
+
+    protected Task RunGenericTestAsync(Type[] typeArguments, object?[] invokeParameters)
+    {
+        var methodName = $"Generic_{new StackTrace().GetFrame(1)?.GetMethod()?.Name}";
+
+        var methodOutput = GetType()
+            .GetMethod(methodName, ~BindingFlags.Public)?
+            .MakeGenericMethod(typeArguments)
+            .Invoke(this, invokeParameters);
+
+        return methodOutput
             .ShouldBeAssignableTo<Task>()
             .ShouldNotBeNull();
     }
@@ -205,6 +219,10 @@ public class TestsBase<TStartup>
         from transactionAdder in AllTransactionAdders
         from entityAdder in AllEntityAdders()
         select new object[] { transactionAdder, entityAdder };
+
+    public static IEnumerable<object[]> AddEntity() =>
+        from entityAdder in AllEntityAdders()
+        select new object[] { entityAdder };
 
     public static IEnumerable<object[]> AddEntitySnapshots() =>
         from entitySnapshotAdder in AllEntitySnapshotAdders()

--- a/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
@@ -68,7 +68,6 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot),
             new[] { entitySnapshotAdder.SnapshotType },
             new object?[] { transactionsAdder, entitySnapshotAdder }
         );
@@ -117,7 +116,6 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot),
             new[] { entitySnapshotAdder.SnapshotType },
             new object?[] { transactionsAdder, entitySnapshotAdder }
         );

--- a/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/EntitySnapshotTransactionSubscriberTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using EntityDb.Abstractions.Entities;
 using EntityDb.Abstractions.Snapshots;
@@ -22,8 +21,8 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
     
     private async Task
         Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot<TEntity>(
-            TransactionsAdder transactionsAdder, SnapshotsAdder snapshotsAdder)
-        where TEntity : IEntity<TEntity>, ISnapshotWithTestMethods<TEntity>
+            TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
@@ -31,8 +30,8 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
         
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
-            snapshotsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
+            entitySnapshotAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();
@@ -63,21 +62,20 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
 
     [Theory]
     [MemberData(nameof(AddTransactionsAndEntitySnapshots))]
-    private async Task
+    private Task
         GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot(
-            TransactionsAdder transactionsAdder, SnapshotsAdder snapshotsAdder)
+            TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
     {
-        await GetType()
-            .GetMethod(nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot), ~BindingFlags.Public)!
-            .MakeGenericMethod(transactionsAdder.EntityType)
-            .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
+        return RunGenericTestAsync
+        (
+            nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsTrue_WhenRunningEntitySnapshotTransactionSubscriber_ThenAlwaysWriteSnapshot),
+            new[] { entitySnapshotAdder.SnapshotType },
+            new object?[] { transactionsAdder, entitySnapshotAdder }
+        );
     }
     
-    private async Task
-        Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot<TEntity>(
-            TransactionsAdder transactionsAdder, SnapshotsAdder snapshotsAdder)
-        where TEntity : IEntity<TEntity>, ISnapshotWithTestMethods<TEntity>
+    private async Task Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot<TEntity>(TransactionsAdder transactionsAdder, SnapshotAdder snapshotAdder)
+        where TEntity : IEntity<TEntity>, ISnapshotWithTestLogic<TEntity>
     {
         // ARRANGE
 
@@ -85,8 +83,8 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
         
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
-            snapshotsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
+            snapshotAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();
@@ -114,14 +112,14 @@ public class EntitySnapshotTransactionSubscriberTests : TestsBase<Startup>
 
     [Theory]
     [MemberData(nameof(AddTransactionsAndEntitySnapshots))]
-    private async Task
-        GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot(
-            TransactionsAdder transactionsAdder, SnapshotsAdder snapshotsAdder)
+    private Task GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot(
+            TransactionsAdder transactionsAdder, SnapshotAdder entitySnapshotAdder)
     {
-        await GetType()
-            .GetMethod(nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot), ~BindingFlags.Public)!
-            .MakeGenericMethod(transactionsAdder.EntityType)
-            .Invoke(this, new object?[] { transactionsAdder, snapshotsAdder })
-            .ShouldBeAssignableTo<Task>().ShouldNotBeNull();
+        return RunGenericTestAsync
+        (
+            nameof(Generic_GivenSnapshotShouldRecordAsMostRecentAlwaysReturnsFalse_WhenRunningEntitySnapshotTransactionSubscriber_ThenNeverWriteSnapshot),
+            new[] { entitySnapshotAdder.SnapshotType },
+            new object?[] { transactionsAdder, entitySnapshotAdder }
+        );
     }
 }

--- a/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/SingleEntityTransactionBuilderTests.cs
@@ -3,7 +3,6 @@ using EntityDb.Abstractions.Transactions.Steps;
 using EntityDb.Common.Exceptions;
 using EntityDb.Common.Leases;
 using EntityDb.Common.Tests.Implementations.Commands;
-using EntityDb.Common.Tests.Implementations.Entities;
 using EntityDb.Common.Transactions.Builders;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
@@ -12,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EntityDb.Abstractions.ValueObjects;
 using Xunit;
+using EntityDb.Common.Entities;
 
 namespace EntityDb.Common.Tests.Transactions;
 
@@ -21,15 +21,18 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
     {
     }
 
-    [Fact]
-    public void GivenEntityNotKnown_WhenGettingEntity_ThenThrow()
+    private void Generic_GivenEntityNotKnown_WhenGettingEntity_ThenThrow<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
-        using var serviceScope = CreateServiceScope();
+        using var serviceScope = CreateServiceScope(serviceCollection =>
+        {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+        });
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(default);
 
         // ASSERT
@@ -39,20 +42,23 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         Should.Throw<KeyNotFoundException>(() => transactionBuilder.GetEntity());
     }
 
-    [Fact]
-    public void GivenEntityKnown_WhenGettingEntity_ThenReturnExpectedEntity()
+    private void Generic_GivenEntityKnown_WhenGettingEntity_ThenReturnExpectedEntity<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
-        using var serviceScope = CreateServiceScope();
+        using var serviceScope = CreateServiceScope(serviceCollection =>
+        {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+        });
 
         var expectedEntityId = Id.NewId();
 
-        var expectedEntity = TestEntity
+        var expectedEntity = TEntity
             .Construct(expectedEntityId);
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(expectedEntityId);
 
         transactionBuilder.Load(expectedEntity);
@@ -72,15 +78,18 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         actualEntity.ShouldBe(expectedEntity);
     }
 
-    [Fact]
-    public void GivenLeasingStrategy_WhenBuildingNewEntityWithLease_ThenTransactionDoesInsertLeases()
+    private void Generic_GivenLeasingStrategy_WhenBuildingNewEntityWithLease_ThenTransactionDoesInsertLeases<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
-        using var serviceScope = CreateServiceScope();
+        using var serviceScope = CreateServiceScope(serviceCollection =>
+        {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+        });
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(default);
 
         // ACT
@@ -92,14 +101,14 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         // ASSERT
 
         transaction.Steps.Length.ShouldBe(1);
-            
+
         var leaseTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAddLeasesTransactionStep>().ShouldNotBeNull();
 
         leaseTransactionStep.Leases.ShouldNotBeEmpty();
     }
 
-    [Fact]
-    public async Task GivenExistingEntityId_WhenUsingEntityIdForLoadTwice_ThenLoadThrows()
+    private async Task Generic_GivenExistingEntityId_WhenUsingEntityIdForLoadTwice_ThenLoadThrows<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
@@ -107,17 +116,19 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddScoped(_ =>
                 GetMockedTransactionRepositoryFactory(
                     new object[] { new DoNothing() }));
         });
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(entityId);
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository(default!);
 
         var entity = await entityRepository.GetSnapshot(entityId);
@@ -134,8 +145,8 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         });
     }
 
-    [Fact]
-    public void GivenNonExistingEntityId_WhenUsingValidVersioningStrategy_ThenVersionNumberAutoIncrements()
+    private void Generic_GivenNonExistingEntityId_WhenUsingValidVersioningStrategy_ThenVersionNumberAutoIncrements<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
@@ -145,12 +156,14 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddScoped(_ =>
                 GetMockedTransactionRepositoryFactory());
         });
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(entityId);
 
         // ACT
@@ -174,8 +187,8 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         }
     }
 
-    [Fact]
-    public async Task GivenExistingEntity_WhenAppendingNewCommand_ThenTransactionBuilds()
+    private async Task Generic_GivenExistingEntity_WhenAppendingNewCommand_ThenTransactionBuilds<TEntity>(EntityAdder entityAdder)
+        where TEntity : IEntity<TEntity>
     {
         // ARRANGE
 
@@ -183,16 +196,18 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
+            entityAdder.AddDependencies.Invoke(serviceCollection);
+
             serviceCollection.AddScoped(_ =>
                 GetMockedTransactionRepositoryFactory(new object[] { new DoNothing() }));
         });
 
         var transactionBuilder = serviceScope.ServiceProvider
-            .GetRequiredService<TransactionBuilder<TestEntity>>()
+            .GetRequiredService<TransactionBuilder<TEntity>>()
             .ForSingleEntity(entityId);
 
         await using var entityRepository = await serviceScope.ServiceProvider
-            .GetRequiredService<IEntityRepositoryFactory<TestEntity>>()
+            .GetRequiredService<IEntityRepositoryFactory<TEntity>>()
             .CreateRepository(default!);
 
         var entity = await entityRepository.GetSnapshot(entityId);
@@ -211,5 +226,71 @@ public class SingleEntityTransactionBuilderTests : TestsBase<Startup>
         var commandTransactionStep = transaction.Steps[0].ShouldBeAssignableTo<IAppendCommandTransactionStep>().ShouldNotBeNull();
 
         commandTransactionStep.Command.ShouldBeEquivalentTo(new DoNothing());
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public void GivenEntityNotKnown_WhenGettingEntity_ThenThrow(EntityAdder entityAdder)
+    {
+        RunGenericTest
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public void GivenEntityKnown_WhenGettingEntity_ThenReturnExpectedEntity(EntityAdder entityAdder)
+    {
+        RunGenericTest
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public void GivenLeasingStrategy_WhenBuildingNewEntityWithLease_ThenTransactionDoesInsertLeases(EntityAdder entityAdder)
+    {
+        RunGenericTest
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenExistingEntityId_WhenUsingEntityIdForLoadTwice_ThenLoadThrows(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public void GivenNonExistingEntityId_WhenUsingValidVersioningStrategy_ThenVersionNumberAutoIncrements(EntityAdder entityAdder)
+    {
+        RunGenericTest
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(AddEntity))]
+    public Task GivenExistingEntity_WhenAppendingNewCommand_ThenTransactionBuilds(EntityAdder entityAdder)
+    {
+        return RunGenericTestAsync
+        (
+            new[] { entityAdder.EntityType },
+            new object?[] { entityAdder }
+        );
     }
 }

--- a/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
@@ -1451,7 +1451,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenReadOnlyMode_WhenPuttingTransaction_ThenCannotWriteInReadOnlyModeExceptionIsLogged),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1463,7 +1462,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenNonUniqueTransactionIds_WhenPuttingTransactions_ThenSecondPutReturnsFalse),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1475,7 +1473,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenNonUniqueVersionNumbers_WhenInsertingCommands_ThenReturnFalse),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1487,7 +1484,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenVersionNumberZero_WhenInsertingCommands_ThenVersionZeroReservedExceptionIsLogged),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1499,7 +1495,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenNonUniqueVersionNumbers_WhenInsertingCommands_ThenOptimisticConcurrencyExceptionIsLogged),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1511,7 +1506,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenNonUniqueTags_WhenInsertingTagDocuments_ThenReturnTrue),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1523,7 +1517,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenNonUniqueLeases_WhenInsertingLeaseDocuments_ThenReturnFalse),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1535,7 +1528,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenCommandInserted_WhenGettingAnnotatedAgentSignature_ThenReturnAnnotatedAgentSignature),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1547,7 +1539,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenCommandInserted_WhenGettingAnnotatedCommand_ThenReturnAnnotatedCommand),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1559,7 +1550,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEntityInserted_WhenGettingEntity_ThenReturnEntity),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1571,7 +1561,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEntityInsertedWithTags_WhenRemovingAllTags_ThenFinalEntityHasNoTags),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1583,7 +1572,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenEntityInsertedWithLeases_WhenRemovingAllLeases_ThenFinalEntityHasNoLeases),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1595,7 +1583,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionCreatesEntity_WhenQueryingForVersionOne_ThenReturnTheExpectedCommand),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1607,7 +1594,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAppendsEntityWithOneVersion_WhenQueryingForVersionTwo_ThenReturnExpectedCommand),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1619,7 +1605,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAlreadyInserted_WhenQueryingByTransactionTimeStamp_ThenReturnExpectedObjects),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1631,7 +1616,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAlreadyInserted_WhenQueryingByTransactionId_ThenReturnExpectedObjects),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1643,7 +1627,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAlreadyInserted_WhenQueryingByEntityId_ThenReturnExpectedObjects),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1655,7 +1638,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAlreadyInserted_WhenQueryingByEntityVersionNumber_ThenReturnExpectedObjects),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );
@@ -1667,7 +1649,6 @@ public sealed class TransactionTests : TestsBase<Startup>
     {
         return RunGenericTestAsync
         (
-            nameof(Generic_GivenTransactionAlreadyInserted_WhenQueryingByData_ThenReturnExpectedObjects),
             new[] { entityAdder.EntityType },
             new object?[] { transactionsAdder, entityAdder }
         );

--- a/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
+++ b/test/EntityDb.Common.Tests/Transactions/TransactionTests.cs
@@ -465,7 +465,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
             
             serviceCollection.RemoveAll(typeof(ILoggerFactory));
             
@@ -501,7 +501,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var transactionId = Id.NewId();
@@ -543,7 +543,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var transaction = (serviceScope.ServiceProvider
@@ -590,7 +590,7 @@ public sealed class TransactionTests : TestsBase<Startup>
         
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
             
             serviceCollection.RemoveAll(typeof(ILoggerFactory));
 
@@ -640,7 +640,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
             
             serviceCollection.RemoveAll(typeof(ILoggerFactory));
             
@@ -699,7 +699,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var tag = TagSeeder.Create();
@@ -731,7 +731,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var lease = LeaseSeeder.Create();
@@ -765,7 +765,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var transactionTimeStamp = TimeStamp.UtcNow;
@@ -824,7 +824,7 @@ public sealed class TransactionTests : TestsBase<Startup>
         
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var transactionTimeStamp = TimeStamp.UtcNow;
@@ -882,7 +882,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();
@@ -919,7 +919,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();
@@ -977,7 +977,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var entityId = Id.NewId();
@@ -1035,7 +1035,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var expectedCommand = new Count(1);
@@ -1084,7 +1084,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
 
         var expectedCommand = new Count(2);
@@ -1143,7 +1143,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
         var originTimeStamp = TimeStamp.UnixEpoch;
 
@@ -1218,7 +1218,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
         
         var transactions = new List<ITransaction>();
@@ -1284,7 +1284,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
         
         var transactions = new List<ITransaction>();
@@ -1351,7 +1351,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
         
         var counts = new List<ulong>();
@@ -1393,7 +1393,7 @@ public sealed class TransactionTests : TestsBase<Startup>
 
         using var serviceScope = CreateServiceScope(serviceCollection =>
         {
-            transactionsAdder.Add(serviceCollection);
+            transactionsAdder.AddDependencies.Invoke(serviceCollection);
         });
         
         var transactions = new List<ITransaction>();


### PR DESCRIPTION
1. Show the docker-compose file for tests in the solution explorer
2. Clean up generic testing
3. Convert all of the non-generic tests that directly reference `TestEntity` and `OneToOneProjection` to generic tests